### PR TITLE
Docs: Add missing word in tip sentence

### DIFF
--- a/docs/concepts/database.md
+++ b/docs/concepts/database.md
@@ -16,7 +16,7 @@ On top of DynamoDB NoSQL functionality and table there is a number of additional
 - JSON Schema Discovery
 
 :::tip  Local Dev 
-When deployed Cyclic apps are directly integrated with AWS resources with no need any additional config.
+When deployed, Cyclic apps are directly integrated with AWS resources with no need for any additional config.
 When developing and interacting with AWS on local, use credentials provided on the `Data / Storage` tab of an app.
 
 ![Transaction Request](/img/cyclic/creds.png "Transaction Request")


### PR DESCRIPTION
This adds the missing word 'for' to one sentence in the Concepts > Databases section of the docs.

This closes #93.