### PR TITLE
Add missing link to Namecheap domains article in custom domains file

### DIFF
--- a/docs/how-to/custom-domains/overview.md
+++ b/docs/how-to/custom-domains/overview.md
@@ -58,6 +58,8 @@ Many registrars support forwarding. A common practice is to register a `www` sub
 - [Custom Domains ⟫ Cloudflare](/how-to/custom-domains/cloudflare)
 ### GoDaddy
 - [Custom Domains ⟫ GoDaddy](/how-to/custom-domains/godaddy)
+### Namecheap
+- [Custom Domains ⟫ Namecheap](/how-to/custom-domains/namecheap)
 
 ## Additional support 
 Reach out to us for any additional support on  [<i className="fab fa-discord"></i>  Discord](https://discord.cyclic.sh/support)


### PR DESCRIPTION
* Add lines 61-62 to `/docs/how-to/custom-domains/overview.md` linking to `/how-to/custom-domains/namecheap` to reflect the recent addition of the page