### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ This command generates static content into the `build` directory and can be serv
 
 ### Deployment
 
-A github action is configured to deploy on any push/merge to main.
+A GitHub action is configured to deploy on any push/merge to main.

--- a/docs/concepts/apps.md
+++ b/docs/concepts/apps.md
@@ -13,7 +13,7 @@ When deployed, they service requests from browsers, servers, other apps, or anyt
 
 ## Infrastructure
 
-Cyclic manages the provisioning, upgrades, instrumentation, configuration and cloud best practices to set your code up with scalable, fault tolerant, serverless infrastructure.
+Cyclic manages the provisioning, upgrades, instrumentation, configuration and cloud best practices to set your code up with scalable, fault-tolerant, serverless infrastructure.
 - **AWS Cloud**: App infrastructure is provisioned and managed as infrastructure as code (IaC) in <a href="https://aws.amazon.com/cloudformation/" target="_blank">AWS CloudFormation</a>
 - **Serverless**: a cloud execution model that enables your apps to be highly scalable, they can process single requests or millions of requests on demand without having to change logic, manage clusters, tune parameters or deploy anything.
 - **Fault Tolerant**: Apps have the capability to be provisioned with <a href="https://aws.amazon.com/blogs/architecture/disaster-recovery-dr-architecture-on-aws-part-iv-multi-site-active-active/" target="_blank">active-active disaster recovery strategy</a> in all AWS regions. This means that applications can be made resilient to severe outages, limiting impact to end-users with zero downtime.
@@ -36,4 +36,4 @@ The repos must contain a `package.json` file to inform the build and runtime pro
 ### Build
 Cyclic follows the instructions provided in `package.json` scripts included in your code. The build environment is transient, all build files/memory is removed after the build. While built apps are [limited](../overview/limits.md) to 250 MB, the build environment can support up to 10GB including dev dependencies.
 
-Cyclic will prune any devDependencies from the build directory before trying to package. Therefore move any frameworks or modules that are only needed at build time into the `devDependencies` section of your `package.json`.
+Cyclic will prune any devDependencies from the build directory before trying to package. Therefore, move any frameworks or modules that are only needed at build time into the `devDependencies` section of your `package.json`.

--- a/docs/concepts/apps.md
+++ b/docs/concepts/apps.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 # Apps
 
 Cyclic apps are a combination of code from a git repository and serverless cloud infrastructure. Each app is a stack like:
-- Infrastructure: Serverless cloud components - Lambda, ApiGateway, SNS/SQS etc.
+- Infrastructure: Serverless cloud components - Lambda, ApiGateway, SNS/SQS, etc.
 - Runtime: Instrumentation and bootstrapping
 - Code: Application code from git
 
@@ -13,9 +13,9 @@ When deployed, they service requests from browsers, servers, other apps, or anyt
 
 ## Infrastructure
 
-Cyclic manages the provisioning, upgrades, instrumentation, configuration and cloud best practices to set your code up with scalable, fault-tolerant, serverless infrastructure.
+Cyclic manages the provisioning, upgrades, instrumentation, configuration, and cloud best practices to set your code up with scalable, fault-tolerant, serverless infrastructure.
 - **AWS Cloud**: App infrastructure is provisioned and managed as infrastructure as code (IaC) in <a href="https://aws.amazon.com/cloudformation/" target="_blank">AWS CloudFormation</a>
-- **Serverless**: a cloud execution model that enables your apps to be highly scalable, they can process single requests or millions of requests on demand without having to change logic, manage clusters, tune parameters or deploy anything.
+- **Serverless**: a cloud execution model that enables your apps to be highly scalable, they can process single requests or millions of requests on demand without having to change logic, manage clusters, tune parameters, or deploy anything.
 - **Fault Tolerant**: Apps have the capability to be provisioned with <a href="https://aws.amazon.com/blogs/architecture/disaster-recovery-dr-architecture-on-aws-part-iv-multi-site-active-active/" target="_blank">active-active disaster recovery strategy</a> in all AWS regions. This means that applications can be made resilient to severe outages, limiting impact to end-users with zero downtime.
 ### Hosting
 We describe hosting in terms of where the underlying app infrastructure is hosted. While the application code is executed on AWS Lambda compute, the Lambdas themselves can be hosted in any AWS cloud account, [ours or yours](./hosting.md).

--- a/docs/concepts/auth.md
+++ b/docs/concepts/auth.md
@@ -9,7 +9,7 @@ Cyclic allows you to add authentication to secure parts of your api with a simpl
 This feature is available on all apps configuration pages in the `Auth` tab
 :::
 
-Authentication and authorization can be very complex. At some point applications may require role and attribute based access control, groups and groups of groups, etc. Cyclic's auth intends to cover applications with less complex access control scenarios to enable you to gradually build more complex mechanisms while the app stays secure. 
+Authentication and authorization can be very complex. At some point, applications may require role and attribute-based access control, groups and groups of groups, etc. Cyclic's auth intends to cover applications with less complex access control scenarios to enable you to gradually build more complex mechanisms while the app stays secure. 
 
 ## Use Cases
 Add API Auth to your endpoints to protect the entire app or individual paths or pages.
@@ -55,7 +55,7 @@ When enabled, Auth is required on requests whenever a certain URL pattern is mat
   - <a href="https://swagger.io/specification/authentication/basic-authentication/" target="_blank">Read more</a> to understand basic auth in detail.
   
 ## Limits
-- Currently only `Basic` auth scheme is available with others coming soon
+- Currently, only the `Basic` auth scheme is available with others coming soon
 - The number of credentials is limited to `3` per app
 - The number of route patterns is limited to `3` per app
 
@@ -63,7 +63,7 @@ When enabled, Auth is required on requests whenever a certain URL pattern is mat
 
 - Enable auth for your app as explained above.
 - Encode username and password using online base64 encoder or bash: `echo -n 'username:password' | base64`
-- Use base64 encoded string in Authorization header:
+- Use base64 encoded string in the Authorization header:
 ```shell
 curl -H "Authorization: Basic $(echo -n 'username:password' | base64)" https://app-url.cyclic.app
 ```

--- a/docs/concepts/auth.md
+++ b/docs/concepts/auth.md
@@ -62,7 +62,7 @@ When enabled, Auth is required on requests whenever a certain URL pattern is mat
 ## Example
 
 - Enable auth for your app as explained above.
-- Encode user name and password using online base64 encoder or bash: `echo -n 'username:password' | base64`
+- Encode username and password using online base64 encoder or bash: `echo -n 'username:password' | base64`
 - Use base64 encoded string in Authorization header:
 ```shell
 curl -H "Authorization: Basic $(echo -n 'username:password' | base64)" https://app-url.cyclic.app

--- a/docs/concepts/database.md
+++ b/docs/concepts/database.md
@@ -100,11 +100,11 @@ If you choose not to use the open source `cyclic-dynamodb` package, apps have CR
 
 When using the table directly with AWS DynamoDB SDK or other third party SDKs, the following fields and indexes can be used:
 
-| IndexName      | Partition Key  | Range Key          | Projected Fields |
-| -----------   | -----------     | ----               |  ----   |
-| primary       | `pk`            |   `sk`             | all |
-| keys_gsi      | `keys_gsi`      |   `keys_gsi_sk`   | `pk`,`sk`, `gsi_prj` |
-| gsi_prj       | `gsi_prj`       |   -               | `prj` |
+| IndexName | Partition Key | Range Key     | Projected Fields     |
+|-----------|---------------|---------------|----------------------|
+| primary   | `pk`          | `sk`          | all                  |
+| keys_gsi  | `keys_gsi`    | `keys_gsi_sk` | `pk`,`sk`, `gsi_prj` |
+| gsi_prj   | `gsi_prj`     | -             | `prj`                |
 
 
 The table also has several attribute names that are reserved and should not be used directly:

--- a/docs/concepts/database.md
+++ b/docs/concepts/database.md
@@ -47,7 +47,7 @@ The package organizes items into the following structure:
   ]
 }
 ```
-The `key` should be used to uniquely identify an item and it's set of child items.
+The `key` should be used to uniquely identify an item and its set of child items.
 
 `$index` is a list of `props` by which them item will be indexed. key-value pairs that have been indexed can be used to retrieve or query items with greater performance.
 
@@ -98,7 +98,7 @@ let mikes_work = await users.item('mike').fragment('work').get()
 
 If you choose not to use the open source `cyclic-dynamodb` package, apps have CRUD access to the table and can make use of the table's generic raw schema directly. 
 
-When using the table directly with AWS DynamoDB SDK or other third party SDK's, the following fields and indexes can be used:
+When using the table directly with AWS DynamoDB SDK or other third party SDKs, the following fields and indexes can be used:
 
 | IndexName      | Partition Key  | Range Key          | Projected Fields |
 | -----------   | -----------     | ----               |  ----   |

--- a/docs/concepts/database.md
+++ b/docs/concepts/database.md
@@ -9,7 +9,7 @@ Apps have access to a pre-configured AWS DynamoDB Table. External databases can 
 
 ## DynamoDB
 An enhanced single-table database built on the fast and globally scalable DynamoDB.
-On top of DynamoDB NoSQL functionality and table there is a number of additional resources that enable features including:
+On top of DynamoDB NoSQL functionality and table, there are a number of additional resources that enable features including:
 - Simple Key-Value inspired SDK
 - Write-Time Indexing
 - Flexible Queries
@@ -17,7 +17,7 @@ On top of DynamoDB NoSQL functionality and table there is a number of additional
 
 :::tip  Local Dev 
 When deployed Cyclic apps are directly integrated with AWS resources with no need for any additional config.
-When developing and interacting with AWS on local, use credentials provided on the `Data / Storage` tab of an app.
+When developing and interacting with AWS locally, use credentials provided on the `Data / Storage` tab of an app.
 
 ![Transaction Request](/img/cyclic/creds.png "Transaction Request")
 
@@ -28,7 +28,7 @@ The credentials are temporary and expire after 60 minutes. New credentials can b
 
 [GitHub](https://github.com/cyclic-software/dynamodb) | [NPM](https://www.npmjs.com/package/@cyclic.sh/dynamodb)
 
-The sdk simplifies the DynamoDB interface and enables collection organization of records, queries and data scheme discovery among other features.
+The sdk simplifies the DynamoDB interface and enables collection organization of records, queries, and data scheme discovery among other features.
 
 ### Collection Items
 The package organizes items into the following structure:
@@ -49,7 +49,7 @@ The package organizes items into the following structure:
 ```
 The `key` should be used to uniquely identify an item and its set of child items.
 
-`$index` is a list of `props` by which them item will be indexed. key-value pairs that have been indexed can be used to retrieve or query items with greater performance.
+`$index` is a list of `props` by which the item will be indexed. key-value pairs that have been indexed can be used to retrieve or query items with greater performance.
 
 ```js
 // example.js
@@ -96,9 +96,9 @@ let mikes_work = await users.item('mike').fragment('work').get()
 ```
 ## Using DynamoDB Directly
 
-If you choose not to use the open source `cyclic-dynamodb` package, apps have CRUD access to the table and can make use of the table's generic raw schema directly. 
+If you choose not to use the open-source `cyclic-dynamodb` package, apps have CRUD access to the table and can make use of the table's generic raw schema directly. 
 
-When using the table directly with AWS DynamoDB SDK or other third party SDKs, the following fields and indexes can be used:
+When using the table directly with AWS DynamoDB SDK or other third-party SDKs, the following fields and indexes can be used:
 
 | IndexName | Partition Key | Range Key     | Projected Fields     |
 |-----------|---------------|---------------|----------------------|

--- a/docs/concepts/env_vars.md
+++ b/docs/concepts/env_vars.md
@@ -11,12 +11,12 @@ Environment variables are key-value pairs defined to match a specific applicatio
 ## Setting Variables
 ### Local
 :::danger Do not put your `.env` file in GitHub
-Especially if your repo is public. Make sure to add `.env` file to your `.gitignore`. If you accidentally push your `.env` file to GitHub, its contents will be permanently in the repository's history - **even if you delete it afterwards**
+Especially if your repo is public. Make sure to add `.env` to your `.gitignore` file. If you accidentally push your `.env` file to GitHub, its contents will be permanently in the repository's history - **even if you delete it afterwards**
 :::
 
 On local, there are many ways to get environment variables into your application. Refer to these popular packages for more info:
 - env-cmd - <a href="https://www.npmjs.com/package/env-cmd" target="_blank">https://www.npmjs.com/package/env-cmd</a> (recommended)
-  - can be used in package.json scripts to inject variables from `.env` without changes to application code. For example: 
+  - can be used in package.json scripts to inject variables from `.env` without changes to the application code. For example: 
     - in `dev` - load local env vars from `.env` and watch for file changes
     - when deployed, Cyclic runs `start`. env-cmd is not needed since variables are available automatically. This way `env-cmd` only has to be a `devDependency` 
     ```js
@@ -49,7 +49,7 @@ All apps are preset with the following variables:
 - `CYCLIC_URL` - the default url of the app
 - `CYCLIC_DB` - the name of the AWS DynamoDB table available to the app
 - `CYCLIC_BUCKET_NAME` - the name of the AWS S3 Bucket available to the app
-- `CYCLIC_APP_ID` - the app environments unique id 
+- `CYCLIC_APP_ID` - the app environment's unique id 
 
 There are two ways to set up variables:
 #### Key-Value Editor:
@@ -81,7 +81,7 @@ Application code on the **backend** has access to variables via `process.env` du
 ### Build
 Environment variables that are set for the runtime are also accessible to the scripts defined in `package.json`
 
-:::caution  Support for variables in first deployment
+:::caution  Support for variables in the first deployment
 Support for setting environment variables before a first deployment is coming soon.
 
 Currently, as a workaround - consider modifying your build step to pass. This will allow you to use the app dashboard to add variables. Once added, revert your build scripts to their original state. Variables will be available for all subsequent builds.
@@ -101,7 +101,7 @@ AWS_SECRET_KEY
 AWS_SECRET_ACCESS_KEY
 ```
 
-If you are using resources in your own AWS account and would like you add your own credentials.
+If you are using resources in your own AWS account and would like to add your own credentials.
 Consider using alternative environment variables and setting the credentials on the SDK clients directly:
 
 ```

--- a/docs/concepts/env_vars.md
+++ b/docs/concepts/env_vars.md
@@ -16,7 +16,7 @@ Especially if your repo is public. Make sure to add `.env` file to your `.gitign
 
 On local, there are many ways to get environment variables into your application. Refer to these popular packages for more info:
 - env-cmd - <a href="https://www.npmjs.com/package/env-cmd" target="_blank">https://www.npmjs.com/package/env-cmd</a> (recommended)
-  - can be used in package.json scripts to injects variables from `.env` without changes to application code. For example: 
+  - can be used in package.json scripts to inject variables from `.env` without changes to application code. For example: 
     - in `dev` - load local env vars from `.env` and watch for file changes
     - when deployed, Cyclic runs `start`. env-cmd is not needed since variables are available automatically. This way `env-cmd` only has to be a `devDependency` 
     ```js

--- a/docs/concepts/file_system.md
+++ b/docs/concepts/file_system.md
@@ -4,10 +4,10 @@ sidebar_position: 4
 
 # File System
 
-The Node.js file system module gives you access to the file system on your local environment. To include the `fs` modules use the `require()` method:
+The Node.js file system module gives you access to the file system in your local environment. To include the `fs` modules use the `require()` method:
 `const fs = require('fs');`
 
-The `fs` method is often used for reading, creating, updating, deleting, and renaming files, however there is a long list of methods, which you can see here in the Node documentation: [https://nodejs.org/api/fs.html](https://nodejs.org/api/fs.html).
+The `fs` module is often used for reading, creating, updating, deleting, and renaming files, though there is a long list of methods that you can see in the Node documentation: [https://nodejs.org/api/fs.html](https://nodejs.org/api/fs.html).
 
 Files created by the `fs` module are read-only once the project is deployed to Cyclic.sh. This results in an `EROFS: Error Read-Only File System` error. 
 

--- a/docs/concepts/file_system.md
+++ b/docs/concepts/file_system.md
@@ -11,8 +11,8 @@ The `fs` method is often used for reading, creating, updating, deleting, and ren
 
 Files created by the `fs` module are read-only once the project is deployed to Cyclic.sh. This results in an `EROFS: Error Read-Only File System` error. 
 
-If you are hitting the `EROFS` error in processing files, one solution is to write to a file that is located in a `/tmp` directory. However, do not use `/tmp` for perminant storage, as is it wiped frequently.
+If you are hitting the `EROFS` error in processing files, one solution is to write to a file that is located in a `/tmp` directory. However, do not use `/tmp` for permanent storage, as is it wiped frequently.
 
-A more perminant solution to this error is to use the Cyclic S3fs drop-in replacement for Node.js `fs`, which gives you acces to an AWS S3 bucket to access as file storage in place of your local file system.
+A more permanent solution to this error is to use the Cyclic S3fs drop-in replacement for Node.js `fs`, which gives you access to an AWS S3 bucket to access as file storage in place of your local file system.
 
 Instructions to use the `@cyclic.sh/s3fs` npm module can be found in the README.md for the module. [Try the S3fs module.](https://github.com/cyclic-software/s3fs)

--- a/docs/concepts/hosting.md
+++ b/docs/concepts/hosting.md
@@ -9,7 +9,7 @@ We describe hosting in terms of where the underlying app infrastructure is hoste
 Cyclic manages limits and constraints as well as the access boundaries and permissions to cloud resources external to the application to maintain logical isolation of your apps. 
 
 ## Self-hosted
-While Cyclic still helps you manage deployments, config and features of the runtime, you have **full control** of the app infrastructure with access to customize, take apart and tinker. This enables use-cases like: 
+While Cyclic still helps you manage deployments, config, and features of the runtime, you have **full control** of the app infrastructure with access to customize, take apart, and tinker. This enables use-cases like:  
   - Integration with other AWS infrastructure in your own accounts like:
     - Connect a Cyclic app to a SageMaker model
     - Use Cyclic apps to produce alerts based on CloudWatch alarms 

--- a/docs/concepts/storage.md
+++ b/docs/concepts/storage.md
@@ -3,13 +3,13 @@ sidebar_position: 4
 ---
 # Storage
 
-Cyclic provides object storage backed by AWS S3. Each app is provisioned with an S3 bucket and allowed read/write access. Any AWS S3 compatible client will work.
+Cyclic provides object storage backed by AWS S3. Each app is provisioned with an S3 bucket and allowed read/write access. Any AWS S3-compatible client will work.
 
 ## Config
 
-Apps running on Cyclic have environment AWS environment variables that provide for access to the app's associated S3 bucket. However, you will need to provide either a `BUCKET` environment variable or set the bucket name directly in your code.
+Apps running on Cyclic have environment AWS environment variables that provide access to the app's associated S3 bucket. However, you will need to provide either a `BUCKET` environment variable or set the bucket name directly in your code.
 
-To access the bucket from local, go to the storage tab of the app, copy credentials and paste on your associated command line. As with running on Cyclic you will need to provide your code or cli the bucket name.
+To access the bucket locally, go to the storage tab of the app, copy the credentials, and paste them on your associated command line. As with running on Cyclic, you will need to provide your code or cli the bucket name.
 
 ## Cost and Limits
 
@@ -93,7 +93,7 @@ app.delete('*', async (req,res) => {
 })
 
 // /////////////////////////////////////////////////////////////////////////////
-// Catch all handler for all other request.
+// Catch all handlers for all other requests.
 app.use('*', (req,res) => {
   res.sendStatus(404).end()
 })

--- a/docs/concepts/transactions.md
+++ b/docs/concepts/transactions.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 We think of a *transaction* as an encapsulation of events that compose a single unit of service for a web application. 
 
-These events consist of an entire end-to-end lifecycle of a single request handled by an app. The Cyclic runtime instruments applications with tooling that captures, measures and aggregates network requests, responses, application logs, errors and exceptions to provide full visibility for each call. 
+These events consist of an entire end-to-end lifecycle of a single request handled by an app. The Cyclic runtime instruments applications with tooling that captures, measures, and aggregates network requests, responses, application logs, errors, and exceptions to provide full visibility for each call. 
 
 ## Transaction components
 Each transaction is composed of:
@@ -19,9 +19,9 @@ Each transaction is composed of:
     - source ip
     - user agent
   - App initialization output
-  - App logging output to console or from any loggers:
+  - App logging output to the console or from any loggers:
     - log payload
-    - type of io `stdout`,`stderr`
+    - type of io `stdout`, `stderr`
   - Exceptions and runtime errors
   - The response from your application:
     - http status code
@@ -53,7 +53,7 @@ On the back end, we had a single api handler at the root `/` route implemented a
       return res.send('ok')
     })
   ```
-Cyclic presents the timeline of the logs, errors and exceptions in context of the request and response in an easy to read, syntax highlighted timeline as:
+Cyclic presents the timeline of the logs, errors, and exceptions in the context of the request and response in an easy-to-read and syntax-highlighted timeline as:
   ![Transaction Timeline](/img/transactions/history.png "Transaction Timeline")
   
 

--- a/docs/how-to/add-private-repository.md
+++ b/docs/how-to/add-private-repository.md
@@ -11,7 +11,7 @@ Follow these steps to deploy a private repository on your Cyclic account.
 2. Select the `Link your own` tab
 3. Type the private repository's name (or portion of it)
 4. Click `Add a private repo...`
-5. In the GitHub pop up add Cyclic app to the private repository
+5. In the GitHub pop up, add the Cyclic app to the private repository
 6. Finish deploying the private repository like a public repository.
 
 ## Add a private repo...

--- a/docs/how-to/add-private-repository.md
+++ b/docs/how-to/add-private-repository.md
@@ -8,11 +8,11 @@ sidebar_position: 1
 Follow these steps to deploy a private repository on your Cyclic account.
 
 1. On the dashboard select `Deploy`
-1. Select the `Link your own` tab
-1. Type the private repository's name (or portion of it)
-1. Click `Add a private repo...`
-1. In the Github pop up add Cyclic app to the private repository
-1. Finish deploying the private repository like a public repository.
+2. Select the `Link your own` tab
+3. Type the private repository's name (or portion of it)
+4. Click `Add a private repo...`
+5. In the GitHub pop up add Cyclic app to the private repository
+6. Finish deploying the private repository like a public repository.
 
 ## Add a private repo...
 

--- a/docs/how-to/create-deploy-to-cyclic-button.md
+++ b/docs/how-to/create-deploy-to-cyclic-button.md
@@ -23,7 +23,7 @@ Renders as:
 
 If you would like to embed HTML directly into a site with a configured target you can set the `app.cyclic.sh` path yourself. Replace `GH_LOGIN` and `GH_REPO` with the values for your GitHub username and repository name.
 
-For example if you wanted to create a fork and deploy button for: https://github.com/seekayel/express-hello-world
+For example, if you wanted to create a fork and deploy button for: https://github.com/seekayel/express-hello-world
 
 The values would be:
 

--- a/docs/how-to/create-deploy-to-cyclic-button.md
+++ b/docs/how-to/create-deploy-to-cyclic-button.md
@@ -9,7 +9,7 @@ Follow these steps to create a button that will allow users to fork your repo an
 
 ## Easy
 
-Just copy this markdown directly into your README.md file inside your repo on Github. The target `https://deploy.cyclic.sh/` uses http referrer header to determine the source repo to use in targeting the `app.cyclic.sh` deploy path.
+Just copy this markdown directly into your README.md file inside your repo on GitHub. The target `https://deploy.cyclic.sh/` uses http referrer header to determine the source repo to use in targeting the `app.cyclic.sh` deploy path.
 
 ```markdown
 [![Deploy to Cyclic](https://deploy.cyclic.sh/button.svg)](https://deploy.cyclic.sh/)
@@ -21,7 +21,7 @@ Renders as:
 
 ## HTML
 
-If you would like to embed HTML directly into a site with a configured target you can set the `app.cyclic.sh` path yourself. Replace `GH_LOGIN` and `GH_REPO` with the values for your Github user name and repository name.
+If you would like to embed HTML directly into a site with a configured target you can set the `app.cyclic.sh` path yourself. Replace `GH_LOGIN` and `GH_REPO` with the values for your GitHub username and repository name.
 
 For example if you wanted to create a fork and deploy button for: https://github.com/seekayel/express-hello-world
 

--- a/docs/how-to/custom-domains/godaddy.md
+++ b/docs/how-to/custom-domains/godaddy.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 Assuming you own `example.com`, registered with GoDaddy:
 ## Subdomains
-Link a subdomain, for example `api.example.com` to a Cyclic app:
+Link a subdomain, for example, `api.example.com` to a Cyclic app:
 
 
 ### Cyclic
@@ -34,7 +34,7 @@ Link a subdomain, for example `api.example.com` to a Cyclic app:
 
 At this point, the SSL certificate is still pending, navigating to your subdomain `https://api.example.com`, will produce a browser error `NET::ERR_CERT_COMMON_NAME_INVALID`. 
 
-Return to Cyclic dashboard. It will take a few minutes (up to 15 but usually less) for a certificate to be issued once the validation record has been entered.
+Return to the Cyclic dashboard. It will take a few minutes (up to 15 but usually less) for a certificate to be issued once the validation record has been entered.
 
 After refreshing, you should see a message that says: 
 ```
@@ -46,14 +46,14 @@ After refreshing, you should see a message that says:
 Link the apex domain `example.com` to a Cyclic app. 
 
 :::caution Apex Domains cannot be linked via CNAME
-   The most common approach is to link the `www` subdomain and use forwarding in GoDaddy to set up redirect from `example.com` to `www.example.com`
+   The most common approach is to link the `www` subdomain and use forwarding in GoDaddy to set up a redirect from `example.com` to `www.example.com`
 :::
 
 ### Cyclic
 **Follow the above _subdomain_ procedure to link `www.example.com` to your Cyclic app. **
 
-After you have set up the records and SSL certificate was issued:
-- Verify that you can access your app via `https://wwww.example.com`.
+After you have set up the records and the SSL certificate was issued:
+- Verify that you can access your app via `https://www.example.com`.
 
 ### GoDaddy
 1. Navigate to _DNS Management_ for the domain, scroll down to the _Forwarding_ section

--- a/docs/how-to/custom-domains/namecheap.md
+++ b/docs/how-to/custom-domains/namecheap.md
@@ -11,11 +11,11 @@ Namecheap is one of the most popular domain registrars but can trip up first-tim
 1. Navigate to the Advanced tab in the application you want to link your custom domain to. 
 2. Enter your domain name in the "Domain Name" field, ex. ```www.mydomainiscool.com```
    ![](/img/domains/customdomain.png)
-1. Even if your domain was purchased as an apex domain (without a ```www``` prefix) include the ```www``` prefix to make sure it points correctly.
-2. Within a minute, you can refresh the page, and your records will be available below.
-3. If you need to cancel and restart for any reason, just hit the "Cancel Request" button.
+3. Even if your domain was purchased as an apex domain (without a ```www``` prefix) include the ```www``` prefix to make sure it points correctly.
+4. Within a minute, you can refresh the page, and your records will be available below.
+5. If you need to cancel and restart for any reason, just hit the "Cancel Request" button.
    ![](/img/domains/cancelrequest.png)
-4. Once Cyclic has issued a DNS record for your domain, you will see a pink highlighted box appear below. There are two sections within this box: Validation Record and Routing Record.
+6. Once Cyclic has issued a DNS record for your domain, you will see a pink highlighted box appear below. There are two sections within this box: Validation Record and Routing Record.
    ![](/img/domains/dnsrecords.png)
 
 Follow the instructions below to use this information to connect to Namecheap.

--- a/docs/how-to/custom-domains/namecheap.md
+++ b/docs/how-to/custom-domains/namecheap.md
@@ -34,7 +34,7 @@ Follow the instructions below to use this information to connect to Namecheap.
    4. Add a second CNAME record where the Host is ```www``` and the Value is your Cyclic generated link.
           ![](/img/domains/cname2.png)
 
-This should complete the pointing of your custom URL to from Namecheap to your application on Cyclic. Bear in mind, it may take up to 48 hours for it to propagate through servers everywhere.
+This should complete the pointing of your custom URL from Namecheap to your application on Cyclic. Bear in mind, it may take up to 48 hours for it to propagate through servers everywhere.
 
 ### Redirects
 

--- a/docs/how-to/custom-domains/overview.md
+++ b/docs/how-to/custom-domains/overview.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 # Overview
 
-Cyclic apps are given random subdomain names at first deployment. The general structure of a name is -
+Cyclic apps are given random subdomain names at the first deployment. The general structure of a name is -
 
 `some-random-words.cyclic.app`
 
@@ -17,7 +17,7 @@ To change the subdomain to something like `myproject.cyclic.app`, navigate to `E
 
 ## Add a domain you own to an app
 
-You can attach a domain you own to a Cyclic app. This requires you to create two DNS records. The first record - to verify that you own the domain so that Cyclic can request the issue of an SSL certificate. The certificates are signed by AWS and are auto-renewed as long as appropriate DNS records exist. The second record, to route requests between your domain and cyclic app.
+You can attach a domain you own to a Cyclic app. This requires you to create two DNS records. The first record - to verify that you own the domain so that Cyclic can request the issue of an SSL certificate. The certificates are signed by AWS and are auto-renewed as long as appropriate DNS records exist. The second record, to route requests between your domain and the Cyclic app.
 
 :::caution CAA Record
    Since Cyclic delegates the issue of the SSL certificate to Amazon AWS, your DNS must allow AWS to create certs for your domain. A Certification Authority Authorization (CAA) record is used to specify which certificate authorities (CAs) are allowed to issue certificates for a domain. 

--- a/docs/how-to/custom-domains/overview.md
+++ b/docs/how-to/custom-domains/overview.md
@@ -13,7 +13,7 @@ You can customize this domain in two ways:
 
 ## Change the subdomain
 
-To change the subdomain to something like `myproject.cyclic.app`, navigate to `Environments` and use the form in the `Custom Subdomain` panel. You will be able to select a any custom domain that hasn't already been used.
+To change the subdomain to something like `myproject.cyclic.app`, navigate to `Environments` and use the form in the `Custom Subdomain` panel. You will be able to select any custom domain that hasn't already been used.
 
 ## Add a domain you own to an app
 

--- a/docs/how-to/using-mongo-db.md
+++ b/docs/how-to/using-mongo-db.md
@@ -6,9 +6,9 @@ sidebar_position: 3
 # Using MongoDB
 
 ## Atlas Configuration
-Cyclic apps do not have static IP's for white listing with Atlas and Cyclic does not offer private networking on free tier.
+Cyclic apps do not have static IPs for white listing with Atlas and Cyclic does not offer private networking on free tier.
 
-Setting `0.0.0.0/0` will enable access to your service cluster from all IP's and make it possible for services to authenticate via connection string.
+Setting `0.0.0.0/0` will enable access to your service cluster from all IPs and make it possible for services to authenticate via connection string.
 
 
 ## Connections in a Serverless Runtime

--- a/docs/how-to/using-mongo-db.md
+++ b/docs/how-to/using-mongo-db.md
@@ -6,9 +6,9 @@ sidebar_position: 3
 # Using MongoDB
 
 ## Atlas Configuration
-Cyclic apps do not have static IPs for white listing with Atlas and Cyclic does not offer private networking on free tier.
+Cyclic apps do not have static IPs for whitelisting with Atlas and Cyclic does not offer private networking on the free tier.
 
-Setting `0.0.0.0/0` will enable access to your service cluster from all IPs and make it possible for services to authenticate via connection string.
+Setting `0.0.0.0/0` will enable access to your service cluster from all IPs and make it possible for services to authenticate via a connection string.
 
 
 ## Connections in a Serverless Runtime
@@ -17,9 +17,9 @@ MongoDB is not an on-demand database and its connection mechanism is persistent,
 
 - Serverless environments are restarted frequently, often right when a request is made. 
 - A route handler may already be trying to serve the request before the `MongoClient.connect` method finishes connecting.
--  This may result in a failure to respond from the server. 
+- This may result in a failure to respond from the server. 
 
-This behavior is possible in traditional long-running environments but occurs much less often  because the connection event happens only when the server is restarted. 
+This behavior is possible in traditional long-running environments but occurs much less often because the connection event happens only when the server is restarted. 
 
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ Apps can be launched around the world to make sure your users see the least late
 ### Right-to-Repair
 We are developers here, sometimes we want to open the box and change everything around. You are welcome to open the hood, poke around or take your apps apart. When **apps grow up**, take them with you, integrate them into _legacy code_.
 :::tip  You can have your own cyclic apps and host them too
-Given a role, **Cyclic can deploy apps into your own AWS account**. This allows you to have total and complete control over your app's infrastructure. Self hosting gives the root access to integrate, customize and set your own limits.
+Given a role, **Cyclic can deploy apps into your own AWS account**. This allows you to have total and complete control over your app's infrastructure. Self-hosting gives the root access to integrate, customize and set your own limits.
 :::
 
 ### CI/CD
@@ -58,13 +58,13 @@ Launch a pre-baked expressjs starter:
 
 ### DIY
 
-You can always link your own repository from github.
+You can always link your own repository from GitHub.
 
 - Sign up: [https://app.cyclic.sh/api/login](https://app.cyclic.sh/api/login)
-- Using github as your login
+- Using GitHub as your login
 - Choose "Link my own", and type in your repo name
 - Click deploy
-- Approve "Cyclic - Preview" app in github
+- Approve "Cyclic - Preview" app in GitHub
 - Watch the terminal for your deployment logs
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,10 +20,10 @@ Even with the free tier. Apps do not have to sleep, wake up, spin up or recycle.
 
 Containers make traffic a constant concern because resources are shared across concurrent requests. 
 
-On Cyclic, serverless functions are allocated to each individual request on demand, making it possible for your apps to hyper scale.
+On Cyclic, serverless functions are allocated to each individual request on demand, making it possible for your apps to hyper-scale.
 
 
-:::danger **Hyper** scale 
+:::danger Hyper-scale 
 On the Cyclic free tier, an individual `1GB RAM` compute instance handles each separate http request. For a single request, this is about ~2x cpu/memory compared to popular container platforms. In a 10 concurrent request scenario, this comparison results in `~200x` or `100GB RAM` available system compute - _on the free tier_!
 
 :::
@@ -38,7 +38,7 @@ Apps can be launched around the world to make sure your users see the least late
 
 
 ### Right-to-Repair
-We are developers here, sometimes we want to open the box and change everything around. You are welcome to open the hood, poke around or take your apps apart. When **apps grow up**, take them with you, and integrate them into _legacy code_.
+We are developers here, and sometimes we want to open the box and change everything around. You are welcome to open the hood, poke around or take your apps apart. When **apps grow up**, take them with you, and integrate them into _legacy code_.
 :::tip  You can have your own cyclic apps and host them too
 Given a role, **Cyclic can deploy apps into your own AWS account**. This allows you to have total and complete control over your app's infrastructure. Self-hosting gives the root access to integrate, customize and set your own limits.
 :::

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,11 +10,11 @@ sidebar_position: 1
 </head>
 
 :::tip  Cyclic is **serverless**
-There are **no servers, no containers, no images, no hours to count.** Each app is deployed entirely on serverless cloud infrastructure.
+There are **no servers, no containers, no images, and no hours to count.** Each app is deployed entirely on serverless cloud infrastructure.
 :::
 ### No Sleep
 
-Even with free tier. Apps do not have to sleep, wake up, spin up or recycle. All front-ends and back-ends are ready on-demand, immediately and at all times. 
+Even with the free tier. Apps do not have to sleep, wake up, spin up or recycle. All front-ends and back-ends are ready on-demand, immediately, and at all times. 
 
 ### No Overload
 
@@ -24,21 +24,21 @@ On Cyclic, serverless functions are allocated to each individual request on dema
 
 
 :::danger **Hyper** scale 
-On Cyclic free tier, an individual `1GB RAM` compute instance handles each separate http request. For a single request, this is about ~2x cpu/memory compared to popular container platforms. In a 10 concurrent request scenario, this comparison results in `~200x` or `100GB RAM` available system compute - _on free tier_!
+On the Cyclic free tier, an individual `1GB RAM` compute instance handles each separate http request. For a single request, this is about ~2x cpu/memory compared to popular container platforms. In a 10 concurrent request scenario, this comparison results in `~200x` or `100GB RAM` available system compute - _on the free tier_!
 
 :::
 <!-- Since apps are only actually running for a This means there are no minutes or hours to measure -->
 
 ### Cloud-scale Database and Storage
-Database and storage on free tier. **1GB of AWS S3 file object storage as well as a 1GB AWS DynamoDB NoSQL database** are available for all apps. Cyclic
+Database and storage on the free tier. **1GB of AWS S3 file object storage as well as a 1GB AWS DynamoDB NoSQL database** are available for all apps. Cyclic
 makes it simple to use the services without having to set up an AWS account. To make using the AWS database even easier, check out our open source [DynamoDB SDK](https://github.com/cyclic-software/db-sdk)
 
 ### Worldwide
-Apps can be launched around the world to make sure your users see the least latency. Apps can also be launched across the world to minimize downtime with default active-active failover strategy. 
+Apps can be launched around the world to make sure your users see the least latency. Apps can also be launched across the world to minimize downtime with the default active-active failover strategy. 
 
 
 ### Right-to-Repair
-We are developers here, sometimes we want to open the box and change everything around. You are welcome to open the hood, poke around or take your apps apart. When **apps grow up**, take them with you, integrate them into _legacy code_.
+We are developers here, sometimes we want to open the box and change everything around. You are welcome to open the hood, poke around or take your apps apart. When **apps grow up**, take them with you, and integrate them into _legacy code_.
 :::tip  You can have your own cyclic apps and host them too
 Given a role, **Cyclic can deploy apps into your own AWS account**. This allows you to have total and complete control over your app's infrastructure. Self-hosting gives the root access to integrate, customize and set your own limits.
 :::
@@ -64,13 +64,13 @@ You can always link your own repository from GitHub.
 - Using GitHub as your login
 - Choose "Link my own", and type in your repo name
 - Click deploy
-- Approve "Cyclic - Preview" app in GitHub
+- Approve the "Cyclic - Preview" app on GitHub
 - Watch the terminal for your deployment logs
 
 
 :::note Language and runtime support
 
-Cyclic supports Node.js 18, 16 and 14 runtimes for both building and running apps. Let us know if you are looking for another language or version: [<i className="fab fa-discord"></i>  Discord](https://discord.gg/huhcqxXCbE) 
+Cyclic supports Node.js 18, 16, and 14 runtimes for both building and running apps. Let us know if you are looking for another language or version: [<i className="fab fa-discord"></i>  Discord](https://discord.gg/huhcqxXCbE) 
 
 
 :::

--- a/docs/overview/architecture.md
+++ b/docs/overview/architecture.md
@@ -26,7 +26,7 @@ For subsequent launches we update the lambda to use your latest code.
 
 ## Design principles
 
-In designing and building Cyclic we must make decisions and trade offs. Here is a statement of the principles that guide our decisions, in priority order.
+In designing and building Cyclic we must make decisions and trade-offs. Here is a statement of the principles that guide our decisions, in priority order.
 
 1. Working vs "Correct"
 2. Fail quickly
@@ -46,11 +46,11 @@ If given the choice we would rather completely break sooner than be partially br
 
 ### Fail predictably
 
-Failure will happen. When it does we should make it repeatable. The same inputs should lead to the same failure. Similar failures should be processed in the same way.
+Failure will happen. When it does, we should make it repeatable. The same inputs should lead to the same failure. Similar failures should be processed in the same way.
 
 ### Fail visibly
 
-When errors happen we should show the error message, stack trace, or known bug. This could mean we need to email the user or tell the world on twitter.
+When errors happen we should show the error message, stack trace, or known bug. This could mean we need to email the user or tell the world on Twitter.
 
 ### Right to repair
 

--- a/docs/overview/architecture.md
+++ b/docs/overview/architecture.md
@@ -6,9 +6,9 @@ sidebar_position: 1
 
 Cyclic apps are built and deployed into AWS. We pre-provision a serverless app using cloudformation.
 
-At first launch we select an available stack and deploy the code for your app into the existing lambda.
+At the first launch, we select an available stack and deploy the code for your app into the existing lambda.
 
-For subsequent launches we update the lambda to use your latest code.
+For subsequent launches, we update the lambda to use your latest code.
 
 ## Components
 
@@ -54,4 +54,4 @@ When errors happen we should show the error message, stack trace, or known bug. 
 
 ### Right to repair
 
-Open source is a statement about whether the software system is even available for inspection. We wish to go a step further. Right to repair means you can take a Cyclic app and poke around inside. You can "eject" at anytime and the app will keep running in your account.
+Open source is a statement about whether the software system is even available for inspection. We wish to go a step further. Right to repair means you can take a Cyclic app and poke around inside. You can "eject" at any time and the app will keep running in your account.

--- a/docs/overview/build.md
+++ b/docs/overview/build.md
@@ -8,9 +8,9 @@ sidebar_position: 2
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta2/css/all.min.css" />
 </head>
 
-Cyclic apps are built and deployed into AWS from code that originates in Github.
+Cyclic apps are built and deployed into AWS from code that originates in GitHub.
 
-To trigger a build and deployment, install the [Cyclic Github app](https://github.com/apps/cyclic-sh) on any public repo. On first installation we will assign your repo to an app and give it a public url such as `random-words.cyclic.app`. We will then build and deploy your app as described below. On future commits to the default branch (for example: merges of PRs or pushes) Github will send a webhook api call to us. We will then perform the same build and deploy steps.
+To trigger a build and deployment, install the [Cyclic GitHub app](https://github.com/apps/cyclic-sh) on any public repo. On first installation we will assign your repo to an app and give it a public url such as `random-words.cyclic.app`. We will then build and deploy your app as described below. On future commits to the default branch (for example: merges of PRs or pushes) GitHub will send a webhook api call to us. We will then perform the same build and deploy steps.
 
 The input of the **build** step is a single commit in a git repo and the output is a zip archive that can be deployed and run inside of an AWS lambda with the Cyclic lambda runtime.
 
@@ -51,7 +51,7 @@ NPM executes several [lifecycle scripts](https://docs.npmjs.com/cli/v8/using-npm
 - `build`
 - `postbuild`
 
-If you have particular needs try putting it into the appropriate lifecycle script. If you have needs beyond what these lifecycle scripts can provide or they don't solve for your use case send us an email: <i className="far fa-envelope"></i> hello@cyclic.sh or join us on [<i className="fab fa-discord"></i>  Discord](https://discord.gg/huhcqxXCbE)
+If you have particular needs try putting it into the appropriate lifecycle script. If you have needs beyond what these lifecycle scripts can provide, or they don't solve for your use case, send us an email: <i className="far fa-envelope"></i> hello@cyclic.sh or join us on [<i className="fab fa-discord"></i>  Discord](https://discord.gg/huhcqxXCbE).
 
 ### Advanced Build Options
 

--- a/docs/overview/build.md
+++ b/docs/overview/build.md
@@ -10,7 +10,7 @@ sidebar_position: 2
 
 Cyclic apps are built and deployed into AWS from code that originates in GitHub.
 
-To trigger a build and deployment, install the [Cyclic GitHub app](https://github.com/apps/cyclic-sh) on any public repo. On first installation we will assign your repo to an app and give it a public url such as `random-words.cyclic.app`. We will then build and deploy your app as described below. On future commits to the default branch (for example: merges of PRs or pushes) GitHub will send a webhook api call to us. We will then perform the same build and deploy steps.
+To trigger a build and deployment, install the [Cyclic GitHub app](https://github.com/apps/cyclic-sh) on any public repo. On the first installation, we will assign your repo to an app and give it a public url such as `random-words.cyclic.app`. We will then build and deploy your app as described below. On future commits to the default branch (for example: merges of PRs or pushes) GitHub will send a webhook api call to us. We will then perform the same build and deploy steps.
 
 The input of the **build** step is a single commit in a git repo and the output is a zip archive that can be deployed and run inside of an AWS lambda with the Cyclic lambda runtime.
 
@@ -51,7 +51,7 @@ NPM executes several [lifecycle scripts](https://docs.npmjs.com/cli/v8/using-npm
 - `build`
 - `postbuild`
 
-If you have particular needs try putting it into the appropriate lifecycle script. If you have needs beyond what these lifecycle scripts can provide, or they don't solve for your use case, send us an email: <i className="far fa-envelope"></i> hello@cyclic.sh or join us on [<i className="fab fa-discord"></i>  Discord](https://discord.gg/huhcqxXCbE).
+If you have particular needs, try putting them into the appropriate lifecycle script. If you have needs beyond what these lifecycle scripts can provide, or they don't solve your use case, send us an email: <i className="far fa-envelope"></i> hello@cyclic.sh or join us on [<i className="fab fa-discord"></i>  Discord](https://discord.gg/huhcqxXCbE).
 
 ### Advanced Build Options
 
@@ -62,14 +62,14 @@ By default, the build process and the above lifecycle scripts:
 -  At runtime `npm run start` is used to execute the application
 
 It is possible to customize this process with _Advanced Build Options_:
-- at the time of first deployment, in the _Advanced_ dropdown
+- at the time of the first deployment, in the _Advanced_ dropdown
   - <img src="/img/build-options/advancedWNode.png" width="350px"/>
 - in  _Environments_ tab > _Build Options_ of an app's dashboard
   - <img src="/img/build-options/buildwithnode2.png" width="650px"/>
 
 #### **Root Path**
 The root path specifies which directory Cyclic will run build scripts. 
-For example for a repository structured as:
+For example, for a repository structured as:
 ```
 ├──/frontend
 |   ├── ...
@@ -82,7 +82,7 @@ For example for a repository structured as:
 To have cyclic run `npm run build` in the `frontend` directory, configure "Root Path" as `/frontend`.
 
 #### **Output Path**
-The contents of the _Output Path_ are bundled for deployment. For example if at the end of the above build, a build directory is generated inside `/frontend`:
+The contents of the _Output Path_ are bundled for deployment. For example, if a build directory is generated inside `/frontend` at the end of the above build:
 ```
 ├──/frontend
 |   ├── build

--- a/docs/overview/deploy.md
+++ b/docs/overview/deploy.md
@@ -6,15 +6,15 @@ sidebar_position: 3
 
 We pre-provision AWS serverless infrastructure to make every deployment, even the first, super fast. This means we are able to deploy in seconds. Usually about 6 seconds for apps with a few dependencies. It can take longer if your app has a long build step (nextjs for example).
 
-For deployments that take place into Cyclic managed accounts this means there is nothing else to worry about. The deployments are so easy and fast there really isn't anything else to say.
+For deployments that take place in Cyclic-managed accounts, this means that there is nothing else to worry about. The deployments are so easy and fast there really isn't anything else to say.
 
 ## Triggering a Deployment
-Code is deployed as soon as it's GitHub repository has been connected to Cyclic. Cyclic will use the GitHub default branch to pull the repo contents. On GitHub the default branch is usually  `main` or `master`. 
+Code is deployed as soon as its GitHub repository has been connected to Cyclic. Cyclic will use the GitHub default branch to pull the repo contents. On GitHub, the default branch is usually `main` or `master`.  
 
 Every `git push` or change to the default branch will trigger a Cyclic deployment. This includes direct pushes as well as pull request merges. 
 
 ### GitHub `Environments` Integration
-Once deployed, apps are linked on the GitHub repo in the `Environments` section on the right hand side of the page:
+Once deployed, apps are linked on the GitHub repo in the `Environments` section on the right-hand side of the page:
 <img src="/img/deploy/1.png" alt="drawing" width="400"/>
 
 For each deployment afterwards, a record will be published with a link to the deployment logs, live site, and corresponding commit hash.

--- a/docs/overview/deploy.md
+++ b/docs/overview/deploy.md
@@ -14,7 +14,7 @@ Code is deployed as soon as it's GitHub repository has been connected to Cyclic.
 Every `git push` or change to the default branch will trigger a Cyclic deployment. This includes direct pushes as well as pull request merges. 
 
 ### GitHub `Environments` Integration
-Once deployed, apps are linked on the Github repo in the `Environments` section on the right hand side of the page:
+Once deployed, apps are linked on the GitHub repo in the `Environments` section on the right hand side of the page:
 <img src="/img/deploy/1.png" alt="drawing" width="400"/>
 
 For each deployment afterwards, a record will be published with a link to the deployment logs, live site, and corresponding commit hash.

--- a/docs/overview/launch.md
+++ b/docs/overview/launch.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # Launch
 
-Cyclic apps are hosted on AWS serverless infrastructure. This means any lambda constraints are inherited. This also means there are no servers to manage, no OS patches to apply, no maintenance windows to schedule and no networking headaches.
+Cyclic apps are hosted on AWS serverless infrastructure. This means any lambda constraints are inherited. This also means there are no servers to manage, no OS patches to apply, no maintenance windows to schedule, and no networking headaches.
 
 There are no servers to start or stop. When your app gets more requests, Lambda will initialize more runtimes for you. We will then start your app and send it all the http traffic.
 
@@ -33,7 +33,7 @@ Port 9001 is reserved for the runtime, other than that any port can be used and 
 
 
 ### Fallbacks
-`npm start` is the default behavior, the following is the full sequence of fallbacks to identify entry point:
+`npm start` is the default behavior, the following is the full sequence of fallbacks to identify the entry point:
 - `npm start` will run the start script defined in `package.json`:
     ```json
     "scripts": {
@@ -51,4 +51,4 @@ Port 9001 is reserved for the runtime, other than that any port can be used and 
 
 ## Failures
 
-If you code fails to initialize then you may get an error at your URL endpoint that says: `Unable to proxy`. This is due to your app either not listening on the correct port or failing to start properly from the call to `npm start`.
+If your code fails to initialize then you may get an error at your URL endpoint that says: `Unable to proxy`. This is due to your app either not listening on the correct port or failing to start properly from the call to `npm start`.

--- a/docs/overview/limits.md
+++ b/docs/overview/limits.md
@@ -6,7 +6,7 @@ sidebar_position: 5
 
 Cyclic apps have limits on capacity and usage. Some of these are inherited from the underlying hosting implementation and some are to protect the quality and stability of the service for all users.
 
-Hard limits cannot be changed. Soft limits may be changed but they require a conversation with us and depending on the use case possibly a paid plan: [chat with us on Discord](https://discord.cyclic.sh/support)
+Hard limits cannot be changed. Soft limits may be changed, but they require a conversation with us and, depending on the use case, possibly a paid plan: [chat with us on Discord](https://discord.cyclic.sh/support)
 
 ## Hard limits
 
@@ -17,7 +17,7 @@ Hard limits cannot be changed. Soft limits may be changed but they require a con
 - No streaming of requests or responses
 - 240 MB final code bundle size per app
 - 512MB of ephemeral disk space mounted at `/tmp`
-  - the data will persist between invokes but there is no guarantee that any further invocations will use the same instance and thus can not be relied on to store persistent data.
+  - the data will persist between invokes, but there is no guarantee that any further invocations will use the same instance and thus can not be relied on to store persistent data.
 - 5 TB single file size in S3 storage
 
 ## Soft limits

--- a/docs/overview/starters.md
+++ b/docs/overview/starters.md
@@ -85,7 +85,7 @@ If you run into issues or have questions on the starters please ask in the suppo
 
 ### Telegram Bot
 
-- Telegram inline queries, commands and interactive inline keyboards
+- Telegram inline queries, commands, and interactive inline keyboards
 - Source: https://github.com/cyclic-software/starter-telegram-bot
 
 [![Deploy](/img/cyclic/deploy.svg)](https://app.cyclic.sh/api/app/deploy/cyclic-software/starter-telegram-bot)

--- a/docs/overview/starters.md
+++ b/docs/overview/starters.md
@@ -78,7 +78,7 @@ If you run into issues or have questions on the starters please ask in the suppo
 
 ### Discord Bot
 
-- Discord Bot starter DM's and Slash commands
+- Discord Bot starter DMs and Slash commands
 - Source: https://github.com/cyclic-software/starter-discord-bot
 
 [![Deploy](/img/cyclic/deploy.svg)](https://app.cyclic.sh/api/app/deploy/cyclic-software/starter-discord-bot)

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -23,7 +23,7 @@ Go to the `Link Your Own` tab on the deployment page. This will let you chose a 
 ---------
 Here is what you need to know:
 
-1. Cyclic supports **nodejs** apps that live in **github repos**
+1. Cyclic supports **nodejs** apps that live in **GitHub repos**
 2. A `package.json` must exist at the root of the repo
 3. On every deployment Cyclic will run `npm install` for production and will prune dev dependencies 
    - Cyclic will also run `npm run build` if a build script has been defined in the `package.json`

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -18,7 +18,7 @@ Launch a pre-baked expressjs starter:
 
 ## Launching your own app
 
-Go to the `Link Your Own` tab on the deployment page. This will let you chose a repo from one of your public GitHub repos.
+Go to the `Link Your Own` tab on the deployment page. This will let you choose a repo from one of your public GitHub repos.
 
 ---------
 Here is what you need to know:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 
 # TLDR
 
-## Quick start example
+## Quickstart example
 
 Launch a pre-baked expressjs starter:
 

--- a/docs/serverless/on-demand.md
+++ b/docs/serverless/on-demand.md
@@ -11,7 +11,7 @@ This can limit some traditional server use cases:
 ### Sockets
 Socket connectivity is not available because it requires the server to continuously be connected to a potentially idle client. [Read more](/troubleshooting/websockets)
 :::note  Workaround
-Some popular socket connection libraries such as `SocketIO` have automatic fallback mechanisms to revert to polling for this scenario. Polling works for many use cases that do not require an instantaneous real-time push from the server.  
+Some popular socket connection libraries such as `SocketIO` have automatic fallback mechanisms to revert to polling for this scenario. Polling works for many use cases that do not require an instantaneous real-time push from the server. 
 
 Keep in mind that polling uses up a lot of requests and choose an appropriate polling rate for your use case that is not excessive.
 :::

--- a/docs/serverless/on-demand.md
+++ b/docs/serverless/on-demand.md
@@ -11,7 +11,7 @@ This can limit some traditional server use cases:
 ### Sockets
 Socket connectivity is not available because it requires the server to continuously be connected to a potentially idle client. [Read more](/troubleshooting/websockets)
 :::note  Workaround
-Some popular socket connection libraries such as `SocketIO` have automatic fallback mechanisms to revert to polling for this scenario. Polling works for many use cases that do not require instantaneous real-time push from server. 
+Some popular socket connection libraries such as `SocketIO` have automatic fallback mechanisms to revert to polling for this scenario. Polling works for many use cases that do not require an instantaneous real-time push from the server.  
 
 Keep in mind that polling uses up a lot of requests and choose an appropriate polling rate for your use-case that is not excessive.
 :::
@@ -32,7 +32,7 @@ The Cyclic dashboard allows you can configure scheduled requests to specific api
 ### Async/Await
 Runtimes are suspended immediately after each response is sent. This means all promises must be resolved before a response is returned. 
 
-In the following snippet, the `db.write` method takes some time. The database will probably be written to on local or in a persistent environment, but this writing actually happens *after* the response `ok` has already been sent.
+In the following snippet, the `db.write` method takes some time. The database will probably be written to a local or persistent environment, but this writing actually happens *after* the response `ok` has already been sent.
 ```javascript
   // BAD CODE - Example of not using await before returning
   router.post('/some_route', requiresAuth(), async (req, res) => {

--- a/docs/serverless/on-demand.md
+++ b/docs/serverless/on-demand.md
@@ -13,7 +13,7 @@ Socket connectivity is not available because it requires the server to continuou
 :::note  Workaround
 Some popular socket connection libraries such as `SocketIO` have automatic fallback mechanisms to revert to polling for this scenario. Polling works for many use cases that do not require an instantaneous real-time push from the server.  
 
-Keep in mind that polling uses up a lot of requests and choose an appropriate polling rate for your use-case that is not excessive.
+Keep in mind that polling uses up a lot of requests and choose an appropriate polling rate for your use case that is not excessive.
 :::
 
 ### Background Processes
@@ -26,7 +26,7 @@ Even though it is not possible to run a background process longer than it takes 
 ### Cron Tasks
 Cron tasks are technically long-running processes and cannot be run in the same way that they do in a unix environment. You can still build the behavior you need by specifying cron tasks in the Cyclic dashboard.
 :::tip  Cron Tasks
-The Cyclic dashboard allows you can configure scheduled requests to specific api routes to run up to once an hour (with one second resolution) or trigger at a specific time (one second resolution).
+The Cyclic dashboard allows you can configure scheduled requests to specific api routes to run up to once an hour (with one-second resolution) or trigger at a specific time (one-second resolution).
 :::
 
 ### Async/Await

--- a/docs/serverless/on-demand.md
+++ b/docs/serverless/on-demand.md
@@ -24,7 +24,7 @@ Even though it is not possible to run a background process longer than it takes 
 :::
 
 ### Cron Tasks
-Cron tasks are technically long running processes and cannot be run in the same way that they do in a unix environment. You can still build the behavior you need by specifying cron tasks in the Cyclic dashboard.
+Cron tasks are technically long-running processes and cannot be run in the same way that they do in a unix environment. You can still build the behavior you need by specifying cron tasks in the Cyclic dashboard.
 :::tip  Cron Tasks
 The Cyclic dashboard allows you can configure scheduled requests to specific api routes to run up to once an hour (with one second resolution) or trigger at a specific time (one second resolution).
 :::

--- a/docs/serverless/stateless.md
+++ b/docs/serverless/stateless.md
@@ -30,7 +30,7 @@ Cyclic exposes many features of AWS S3 directly to your apps. To handle uploads 
 The `/tmp` directory can be written to. But it should only be used for intermediary processing. Either upload the result to an object store or download to the client. An example use case for `/tmp` may be to create thumbnail images, store them in /tmp, and then upload them to S3.
 
 ### db.json
-A popular pattern with many tutorials is to simulate a database by reading and writing records to and from a `db.json` file. In traditional server environments, this pattern may work for some *very* low volume of read's and write's, it will very quickly become vulnerable to race conditions and should be avoided even in those environments.
+A popular pattern with many tutorials is to simulate a database by reading and writing records to and from a `db.json` file. In traditional server environments, this pattern may work for some *very* low volume of reads and writes, it will very quickly become vulnerable to race conditions and should be avoided even in those environments.
 
 While it is possible to write to the `/tmp` directory in a stateless runtime, the `/tmp` directory is not shared between multiple instances of the application and is lost after each shutdown. This makes the same issues that arise in a stateful environment immediately apparent. 
 

--- a/docs/serverless/stateless.md
+++ b/docs/serverless/stateless.md
@@ -3,31 +3,31 @@ sidebar_position: 3
 ---
 
 # Stateless
-Cyclic apps run on read-only file systems amd do not retain or share memory across compute instances.
+Cyclic apps run on read-only file systems and do not retain or share memory across compute instances.
 
 ## Limitations and Solutions 
 
-Special precautions should be used for the following use-cases:
+Special precautions should be used for the following use cases:
 
 ### In-Memory Sessions
-Basic session implementations are usually built with the assumption that the server process is never interrupted. This can be an issue even in stateful environments, where a server re-start will cause sessions to be lost. With serverless runtimes, re-starts happen quickly *(~0.2s)* and frequently.
+Basic session implementations are usually built with the assumption that the server process is never interrupted. This can be an issue even in stateful environments, where a server restart will cause sessions to be lost. With serverless runtimes, restarts happen quickly *(~0.2s)* and frequently.
 
-:::tip Database backed sessions
+:::tip Database-backed sessions
 Best practices for stateful environments will dictate that sessions should be backed up to a database. With serverless, storing sessions in a database is a must. There are many libraries and session extensions that enable this for a variety of databases.
 
- Check out our npm package that will let you use apps' built-in AWS DynamoDB database for session storage. >> [@cyclic.sh/session-store](https://www.npmjs.com/package/@cyclic.sh/session-store)
+Check out our npm package that will let you use your apps' built-in AWS DynamoDB database for session storage. >> [@cyclic.sh/session-store](https://www.npmjs.com/package/@cyclic.sh/session-store)
 :::
 
 ### File Upload
 Serverless apps run on read-only file systems. This means it is impossible to persistently store files to disk. 
 
 :::tip AWS S3 and Uploading/Downloading Files 
-Cyclic exposes many features of AWS S3 directly to your apps. To handle uploads directly to the object store, S3 can be used to generate pre-signed GET, PUT and POST urls than can be used by a client to upload and download files over the 6MB api size limitation. 
+Cyclic exposes many features of AWS S3 directly to your apps. To handle uploads directly to the object store, S3 can be used to generate pre-signed GET, PUT, and POST urls than can be used by a client to upload and download files over the 6MB api size limitation. 
 
 [Read more on presigned URLs](https://aws.amazon.com/blogs/developer/generate-presigned-url-modular-aws-sdk-javascript/)
 :::
 #### Processing and Uploading 
-The `/tmp` directory can be written to. But it should only be used for intermediary processing. Either upload the result to an object store or download to the client. An example use case for `/tmp` may be to create thumbnail images, store them in /tmp, and then upload them to S3.
+The `/tmp` directory can be written to. But it should only be used for intermediary processing. Either upload the result to an object store or download it to the client. An example use case for `/tmp` may be to create thumbnail images, store them in /tmp, and then upload them to S3.
 
 ### db.json
 A popular pattern with many tutorials is to simulate a database by reading and writing records to and from a `db.json` file. In traditional server environments, this pattern may work for some *very* low volume of reads and writes, it will very quickly become vulnerable to race conditions and should be avoided even in those environments.

--- a/docs/troubleshooting/error-codes.md
+++ b/docs/troubleshooting/error-codes.md
@@ -4,7 +4,7 @@
 
 # Common Error Codes
 
-No list of common error codes is exhaustive, but the following should help you quickly find an error based on type and navigate to relevant documentation which may help you resolve it.
+No list of common error codes is exhaustive, but the following should help you quickly find an error based on its type and navigate to relevant documentation which may help you resolve it.
 
 ### Build Options Errors
 
@@ -19,7 +19,7 @@ No list of common error codes is exhaustive, but the following should help you q
 
 ### Timeout Error
 
-- __Timeout error__ - We have a 30 second hard limit on requests.
+- __Timeout error__ - We have a 30-second hard limit on requests.
   - See [Background Processes](/docs/serverless/on-demand.md#background-processes)
 
 ### Database Errors

--- a/docs/troubleshooting/error-codes.md
+++ b/docs/troubleshooting/error-codes.md
@@ -34,11 +34,11 @@ No list of common error codes is exhaustive, but the following should help you q
 ### Other Errors
 
 - __Cannot find module " "__ - If Cyclic is unable to find or run a specific module, it may not be available to Cyclic because of errors in the code or because it is not supported.
-  - Ex: CORS - Make sure CORS is installed and required if you are receiving this message in regards to CORS.
+  - Ex: CORS - Make sure CORS is installed and required if you are receiving this message regarding CORS.
   - EX: Websockets - If you see "Cannot Find Modules 'ws'", it is in reference to WebSockets. Read more about Cyclic and [Websockets here.](/docs/troubleshooting/websockets.md)
 - __npm ERR! gyp ERR!__ - Node-gyp requires Python. Because Python is not currently supported on Cyclic, you will not be able to use this package on Cyclic, resulting in this error. Even if you are not actively using Python in your code, you will encounter this error.
 - __```ERROR```:Failed to run "npm run start"__ - Make sure your package.json is in the build folder.
-- __"Runs on local, but doesn't run on Cyclic"__ - Not an error code, persay, but a frequent concern. Here's how to troubleshoot:
-  - Check package.json has all required dependences
+- __"Runs on local, but doesn't run on Cyclic"__ - Not an error code, per se, but a frequent concern. Here's how to troubleshoot:
+  - Check package.json has all required dependencies
   - Check that your start script is defined and runs 
-  - Check your environment varibales are set and match your expectations
+  - Check your environment variables are set and match your expectations

--- a/docs/troubleshooting/main-entry-point-does-not-exist.md
+++ b/docs/troubleshooting/main-entry-point-does-not-exist.md
@@ -23,7 +23,7 @@ To fix do the following:
 
 ## Solution
 
-Cyclic launches your code by running `node .`. By default this will look for a `main` entry in your `package.json`. If that entry does not exist it will then default to `server.js`.
+Cyclic launches your code by running `node .`. By default, this will look for a `main` entry in your `package.json`. If that entry does not exist it will then default to `server.js`.
 
 Either you can define a `main` entry that points to your entry point - for example:
 
@@ -38,4 +38,4 @@ Or, you can ensure the entry point to your Express application is a `server.js` 
 
 ## Why does this happen?
 
-By default when you run `npm init` it creates a `main` entry in `package.json` which points to `index.js`. Most frameworks init their entry points in files other than `index.js` in the root directory. Hence the mismatch in default behavior.
+By default, when you run `npm init`, it creates a `main` entry in `package.json` which points to `index.js`. Most frameworks init their entry points in files other than `index.js` in the root directory, hence the mismatch in default behavior.

--- a/docs/troubleshooting/no-space-left-on-device.md
+++ b/docs/troubleshooting/no-space-left-on-device.md
@@ -19,7 +19,7 @@ Several SPA frameworks (including React) by default include build time tools in 
  production dependencies cannot exceed 240MB. The total size of your build is ${mb} MB
 ```
 
-If you get an error in the deploy log that says `production dependencies cannot exceed 240MB`, here is how to fix.
+If you get an error in the deploy log that says `production dependencies cannot exceed 240MB`, here is how to fix it.
 
 ### Solution
 Currently, the code size is limited to 240MB. Fortunately, most projects are can to be optimized by appropriately organizing dependencies and excluding unnecessary files from the build. 
@@ -32,7 +32,7 @@ Read more about <a href="https://www.atlassian.com/git/tutorials/saving-changes/
 :::
 
 ## Build environment limit
-The build environment has 10 GB disk and 10 GB RAM available for temporary use to run installation and build `npm` scripts defined in the repos `package.json`.
+The build environment has 10 GB disk and 10 GB RAM available for temporary use to run the installation and build `npm` scripts defined in the repos `package.json`.
 ## Error message
 If your space requirements exceed these amounts, while running the installation or step you will see a `No space left on device` error.
 

--- a/docs/troubleshooting/no-space-left-on-device.md
+++ b/docs/troubleshooting/no-space-left-on-device.md
@@ -8,7 +8,7 @@ Cyclic builds and deploys apps using serverless technologies. The build environm
 The built bundle may not exceed 240 MB.
 
 ## Bundle limit
-The size of the packaged code that is deployed is limited to 240 MB. By default any generated files and the entire repo contents are packaged. 
+The size of the packaged code that is deployed is limited to 240 MB. By default, any generated files and the entire repo contents are packaged. 
 
 Several SPA frameworks (including React) by default include build time tools in standard generated `dependencies`. If you move these to `devDependencies` you will most likely resolve any space issues.
 
@@ -22,7 +22,7 @@ Several SPA frameworks (including React) by default include build time tools in 
 If you get an error in the deploy log that says `production dependencies cannot exceed 240MB`, here is how to fix.
 
 ### Solution
-Currently the code size is limited to 240MB. Fortunately, most projects are can to be optimized by appropriately organizing dependencies and excluding unnecessary files from the build. 
+Currently, the code size is limited to 240MB. Fortunately, most projects are can to be optimized by appropriately organizing dependencies and excluding unnecessary files from the build. 
 - remove any unused dependencies
 - move any dev dependencies to `devDependencies`
 - add file patterns to an `.npmignore` file to exclude them from the build
@@ -34,7 +34,7 @@ Read more about <a href="https://www.atlassian.com/git/tutorials/saving-changes/
 ## Build environment limit
 The build environment has 10 GB disk and 10 GB RAM available for temporary use to run installation and build `npm` scripts defined in the repos `package.json`.
 ## Error message
-If your space requirements exceed these amounts, while running the install or step you will see a `No space left on device` error.
+If your space requirements exceed these amounts, while running the installation or step you will see a `No space left on device` error.
 
 ```code
 fatal: cannot create directory at 'some_large_file.txt': No space left on device

--- a/docs/troubleshooting/no-space-left-on-device.md
+++ b/docs/troubleshooting/no-space-left-on-device.md
@@ -22,7 +22,7 @@ Several SPA frameworks (including React) by default include build time tools in 
 If you get an error in the deploy log that says `production dependencies cannot exceed 240MB`, here is how to fix it.
 
 ### Solution
-Currently, the code size is limited to 240MB. Fortunately, most projects are can to be optimized by appropriately organizing dependencies and excluding unnecessary files from the build. 
+Currently, the code size is limited to 240MB. Fortunately, most projects can be optimized by appropriately organizing dependencies and excluding unnecessary files from the build. 
 - remove any unused dependencies
 - move any dev dependencies to `devDependencies`
 - add file patterns to an `.npmignore` file to exclude them from the build

--- a/docs/troubleshooting/nodemon.md
+++ b/docs/troubleshooting/nodemon.md
@@ -43,7 +43,7 @@ This is happening because your `package.json` is using nodemon in its start scri
 }
 ...
 ```
-Nodemon is an excellent tool for local development of node applications. On your local, nodemon watches for file changes at the path it is monitoring and restarts the local server. In production mode, both for serverless or not - restarting the server on file changes is usually not a desired behavior. 
+Nodemon is an excellent tool for locally developing node applications. Locally, nodemon watches for file changes at the path it is monitoring and restarts the local server. In production mode, serverless or not - restarting the server on file changes is usually not a desired behavior. 
 
 The above `package.json` should be changed to:
 ```json
@@ -56,7 +56,7 @@ The above `package.json` should be changed to:
 ...
 ```
 
-While the `"start"` script may differ for various node frameworks, it should be defined for the purpose of starting the application in production mode with the appropriate flags and parameters. By convention the `"dev"` script is used to start the application in development mode primarily for running on local installations.
+While the `"start"` script may differ for various node frameworks, it should be defined to start the application in production mode with the appropriate flags and parameters. By convention, the `"dev"` script is used to start the application in development mode primarily for running on local installations.
 
 ## Watch an overview here: 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/L49HvtJ2kXY" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/docs/troubleshooting/websockets.md
+++ b/docs/troubleshooting/websockets.md
@@ -8,9 +8,9 @@ Websockets are currently not supported in Cyclic apps.
 
 ## Why?
 
-Serverless functions are active on-demand for just long enough to process a single event. After the processing task is finished, often just a few milliseconds, the runtime is suspended until it is again invoked by another event. The on-demand short lifecycle enables applications to have massive scalability with almost no idle cost. 
+Serverless functions are active on-demand for just long enough to process a single event. After the processing task is finished, often just a few milliseconds, the runtime is suspended until it is invoked again by another event. The on-demand short lifecycle enables applications to have massive scalability with almost no idle cost. 
 
-Websockets require a persistent bidirectional link. In most websockets implementations, for an idle connection, a compute instance must be reserved for the duration of the connection regardless of whether a message is available for processing or not. At the same time, if a high traffic volume is possible - potentially many compute instances should be reserved in anticipation. This creates the need for further complexity in capacity planning and  managing tasks to facilitate the scaling up and down of the sizing and number of compute instances.
+Websockets require a persistent bidirectional link. In most websockets implementations, for an idle connection, a compute instance must be reserved for the duration of the connection regardless of whether a message is available for processing or not. At the same time, if a high traffic volume is possible - potentially many compute instances should be reserved in anticipation. This creates the need for further complexity in capacity planning and managing tasks to facilitate the scaling up and down of the sizing and number of compute instances.
 
 ## Possible Alternatives
 

--- a/docs/troubleshooting/websockets.md
+++ b/docs/troubleshooting/websockets.md
@@ -10,7 +10,7 @@ Websockets are currently not supported in Cyclic apps.
 
 Serverless functions are active on-demand for just long enough to process a single event. After the processing task is finished, often just a few milliseconds, the runtime is suspended until it is again invoked by another event. The on-demand short lifecycle enables applications to have massive scalability with almost no idle cost. 
 
-Websockets require a persistent bi-directional link. In most websockets implementations, for an idle connection, a compute instance must be reserved for the duration of the connection regardless of whether a message is available for processing or not. At the same time, if a high traffic volume is possible - potentially many compute instances should be reserved in anticipation. This creates the need for further complexity in capacity planning and  managing tasks to facilitate the scaling up and down of the sizing and number of compute instances.
+Websockets require a persistent bidirectional link. In most websockets implementations, for an idle connection, a compute instance must be reserved for the duration of the connection regardless of whether a message is available for processing or not. At the same time, if a high traffic volume is possible - potentially many compute instances should be reserved in anticipation. This creates the need for further complexity in capacity planning and  managing tasks to facilitate the scaling up and down of the sizing and number of compute instances.
 
 ## Possible Alternatives
 

--- a/docs/tutorials/rest-api-and-dynamodb/part-1.md
+++ b/docs/tutorials/rest-api-and-dynamodb/part-1.md
@@ -211,7 +211,7 @@ curl "https://bikes.cyclic.app/bikes/search/by-title/?query=Mountain" | jq .
 
 <p align="center"><img alt="Response to the previous command." src="/img/tutorial/rest-api/3.svg" width="640" /></p>
 
-We can also make make POST requests to our API using `cURL`; let's create a new bike item.
+We can also make POST requests to our API using `cURL`; let's create a new bike item.
 
 ```json
 // request.json
@@ -263,7 +263,7 @@ curl -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" https
 
 <p align="center"><img alt="Response to the previous command." src="/img/tutorial/rest-api/6.svg" width="640" /></p>
 
-As you can see, `cURL` is pretty powerful and we'll be using it time and again throughout this guide.
+As you can see, `cURL` is pretty powerful, and we'll be using it time and again throughout this guide.
 
 ### Using AWS DynamoDB to store & retrieve data
 
@@ -309,9 +309,9 @@ Cyclic offers its users with a variety of starter templates, and REST APIs are i
 
 [![Deploy to Cyclic](https://deploy.cyclic.sh/button.svg)](https://app.cyclic.sh/api/app/deploy/cyclic-software/starter-rest-api)
 
-This will fork the aforementioned starter repository to your own Github account (that you used to sign in with Cyclic).
+This will fork the aforementioned starter repository to your own GitHub account (that you used to sign in with Cyclic).
 
-Proceed by cloning the repository to your local machine using the `git clone` command, which you can copy from Github. Make sure that `git` is installed on your machine, of course.
+Proceed by cloning the repository to your local machine using the `git clone` command, which you can copy from GitHub. Make sure that `git` is installed on your machine, of course.
 
 We'll be using ECMA6 import and export statement in this project, so open `package.json` and set the project's type to "module".
 

--- a/docs/tutorials/rest-api-and-dynamodb/part-1.md
+++ b/docs/tutorials/rest-api-and-dynamodb/part-1.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Getting Started with a RESTful API
 
-This five-part series will show you how to build an API from the ground-up using Node's Express and AWS DynamoDB.
+This five-part series will show you how to build an API from the ground up using Node's Express and AWS DynamoDB.
 
 We'll build an API that simply reads and writes data about bikes, a perfect start for an e-commerce shop. We'll also be using Cyclic to host our API for free, including the DynamoDB storage.
 
@@ -20,11 +20,11 @@ You can check out this project's [full code on GitHub](https://github.com/cyclic
 
 <p align="center"><img alt="Browsers and web servers communicating back-and-forth using HTTP requests and responses." src="/img/tutorial/rest-api/Web_Servers.png" width="640" /></p>
 
-Before we delve deeper into RESTful APIs, let's start from its origins and make sure that we all agree on what a _web server_ is.
+Before we delve deeper into RESTful APIs, let's start from their origins and make sure that we all agree on what a _web server_ is.
 
-From a hardware point-of-view, a web **server** is a physical computer that stores and **_serves_** data over the Internet, and that includes everything from HTML documents, CSS stylesheets, images and video files.
+From a hardware point-of-view, a web **server** is a physical computer that stores and **_serves_** data over the Internet, and that includes everything from HTML documents, CSS stylesheets, images, and video files.
 
-Furthermore, every web server must run an **HTTP server**. That's a piece of software that takes-in URLs and processes them to deliver content back to the end-users, while using the HTTP protocol to facilitate the sharing of information over the Internet.
+Furthermore, every web server must run an **HTTP server**. That's a piece of software that takes in URLs and processes them to deliver content back to the end-users while using the HTTP protocol to facilitate the sharing of information over the Internet.
 
 :::tip
 And if the URL is wrong, the server will generate a response with the infamous 404 code instead.
@@ -32,7 +32,7 @@ And if the URL is wrong, the server will generate a response with the infamous 4
 
 ### Servers communicate with browsers using the HTTP protocol
 
-When you search for a product, view details on it or even buy it, an **HTTP request** is sent to a web server.
+When you search for a product, view details on it, or even buy it, an **HTTP request** is sent to a web server.
 
 HTTP is a web standard that allows _any_ server to know what to expect when it receives an _HTTP request_:
 
@@ -41,13 +41,13 @@ HTTP is a web standard that allows _any_ server to know what to expect when it r
 - a method defining the desired action, (whether to get, create or delete that resource)
 - JSON data encoded in the request body or in associated cookies.
 
-HTTP servers proceed by processing the request, then sending an _HTTP response_ back to the sender. The response includes a _status line_ indicating the result of that operation. Success for example, is represented with the `HTTP/1.1 200 OK` code. Unavailable resources would instead respond with the `HTTP/1.1 404 NOT FOUND` code.
+HTTP servers proceed by processing the request, then sending an _HTTP response_ back to the sender. The response includes a _status line_ indicating the result of that operation. Success, for example, is represented with the `HTTP/1.1 200 OK` code. Unavailable resources would instead respond with the `HTTP/1.1 404 NOT FOUND` code.
 
-And just like any other resource, _static websites_ are just HTML files hosted on web servers. (with a hint of CSS files, JS files and other media)
+And just like any other resource, _static websites_ are just HTML files hosted on web servers. (with a hint of CSS files, JS files, and other media)
 
 ---
 
-Sounds good, we just learnt that servers are the building-blocks of the Internet, and that they're responsible for storing _static_ resources and serving them back to the users of the Internet.
+Sounds good, we just learnt that servers are the building blocks of the Internet and that they're responsible for storing _static_ resources and serving them back to the users of the Internet.
 
 But what about websites that are always changing? Think Walmart, for example. It's an online store that's constantly changing:
 
@@ -74,7 +74,7 @@ Instead of delivering whole HTML files, APIs _only_ return useful information (u
 ]
 ```
 
-It may fetch this data from a database that's maintained by an entirely different department in Walmart. The sender of the HTTP request, then, can solely focus on using this information to build a website and show it to the end-user.
+It may fetch this data from a database that's maintained by an entirely different department in Walmart. The sender of the HTTP request, then, can solely focus on using this information to build a website and show it to the end user.
 
 Web servers are critical in the creation of APIs that rely on **dynamic** data:
 
@@ -86,9 +86,9 @@ With this kind of separation, our website can use JavaScript to fetch data from 
 
 Furthermore, server-side code can be written in a variety of programming languages, including but not limited to PHP, Python, Ruby, and C#. But why stray away from the same language that we already use in client-side programming?
 
-With Node, we're able to write our back-end code in JavaScript, giving us full access to the server operating system. (storage, networking, scheduling, and more.) It runs directly in the server operating system, while adding new modules including HTTP and file-system libraries.
+With Node, we're able to write our back-end code in JavaScript, giving us full access to the server operating system. (storage, networking, scheduling, and more.) It runs directly in the server operating system while adding new modules including HTTP and file-system libraries.
 
-When both the front-end and back-end sides of an application are written in the same language, developers experience less of "context shift", making it ideal for large-scale projects.
+When both the front-end and back-end sides of an application are written in the same language, developers experience less of a "context shift", making it ideal for large-scale projects.
 
 ```javascript
 // Example of a web server written in Node
@@ -151,7 +151,7 @@ Thankfully, Node comes with its own package manager, giving us access to a pleth
 - Reading query data straight from HTTP requests,
 - Running "middleware" for any routes before handling the requests. (Useful for authentication)
 
-Express also comes with its own bundle of community-made middleware to handle all kinds of necessities such as parsing cookies and security headers. We'll be using Express in the remainder of this tutorial.
+Express also comes with its own bundle of community-made middleware to handle all kinds of necessities such as parsing cookies and security headers. We'll be using Express for the remainder of this tutorial.
 
 ### Let's understand RESTful APIs
 
@@ -231,7 +231,7 @@ We can also make POST requests to our API using `cURL`; let's create a new bike 
       "amount": 2303
     }
   },
-  "description": "Ride the greatest line of your life with the all new and updated Countach from Cyclic. Make no compromises between speed, handling and durability.",
+  "description": "Ride the greatest line of your life with the all-new and updated Countach from Cyclic. Make no compromises between speed, handling, and durability.",
   "title": "Mountain Bicycle Countach"
 }
 ```
@@ -242,7 +242,7 @@ curl -H "Content-Type: application/json" https://bikes.cyclic.app/bikes/ -d @req
 
 <p align="center"><img alt="Response to the previous command." src="/img/tutorial/rest-api/4.svg" width="640" /></p>
 
-Uh-oh, we just got an HTTP `UNAUTHORIZED` error. After looking-up the meaning of [HTTP status codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status), we see that "UNAUTHORIZED" means that we do not have access to that particular route, yet. (and of course, we'll be building this authentication system ourselves in this article)
+Uh-oh, we just got an HTTP `UNAUTHORIZED` error. After looking up the meaning of [HTTP status codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status), we see that "UNAUTHORIZED" means that we do not have access to that particular route, yet. (and of course, we'll be building this authentication system ourselves in this article)
 
 After looking up our [API's documentation on GitHub](https://github.com/cyclic-software/tutorial-bikes-api), we learn that a "Bearer token" is required to make POST requests.
 
@@ -271,11 +271,11 @@ As you can see, `cURL` is pretty powerful, and we'll be using it time and again 
 
 As we just learned, RESTful APIs are built around databases. But _what_ really is a database?
 
-Well, a database is a set of inter-connected collections of information. For example, a database may contain a collection of users and a collection of products. Users and products may be connected through shopping carts. (Product A exists in User B's shopping cart)
+Well, a database is a set of interconnected collections of information. For example, a database may contain a collection of users and a collection of products. Users and products may be connected through shopping carts. (Product A exists in User B's shopping cart)
 
-Some databases require every collection to have a fixed-set of data-points. For example, a user might have a name, a phone number and an email address. That would be the constraint in a **schema**-enabled database. Collections might also be seen as tables in this case, with a fixed number of columns that have their own data-type. (such as text, integer, booleans, and more)
+Some databases require every collection to have a fixed set of data points. For example, a user might have a name, a phone number, and an email address. That would be the constraint in a **schema**-enabled database. Collections might also be seen as tables in this case, with a fixed number of columns that have their own data type. (such as text, integer, booleans, and more)
 
-On the other hand, schema-less databases have no such limitation. Each item in a collection is a JSON document, and it can have any structure desired. Such databases are also referred to as noSQL databases, while their counterparts are known as SQL databases. A user, for example, might have the following entry in a noSQL database:
+On the other hand, schema-less databases have no such limitation. Each item in a collection is a JSON document, and it can have any structure desired. Such databases are also referred to as NoSQL databases, while their counterparts are known as SQL databases. A user, for example, might have the following entry in a NoSQL database:
 
 ```json
 {
@@ -287,9 +287,9 @@ On the other hand, schema-less databases have no such limitation. Each item in a
 
 SQL is a language used for processing schema-enabled databases. It allows for the efficient searching and processing of information even on the biggest databases out there.
 
-But with DynamoDB, a noSQL database engineered by Amazon's Web Services (AWS), you still get to enjoy almost the whole power of SQL whilst feeling the freedom that comes with schema-less databases. It's called [PartiQL](https://partiql.org/).
+But with DynamoDB, a NoSQL database engineered by Amazon's Web Services (AWS), you still get to enjoy almost the whole power of SQL whilst feeling the freedom that comes with schema-less databases. It's called [PartiQL](https://partiql.org/).
 
-We're building a bikes shop API, so our database should contain a collection of bikes. It's a mix of Strings, Numbers and even whole Objects.
+We're building a bike shop API, so our database should contain a collection of bikes. It's a mix of Strings, Numbers, and even whole Objects.
 
 Keep reading to see how we'll be shaping our API around this database.
 
@@ -303,9 +303,9 @@ Keep reading to see how we'll be shaping our API around this database.
 
 and it won't hurt to take a quick refresher on ES6 JavaScript programming.
 
-We just spent a lot of time trying to understand REST in theory, but nothing can beat learning by practice. So let's create our own API. Our theme is a bikes shop, so that's how we'll be modelling our RESTful routes.
+We just spent a lot of time trying to understand REST in theory, but nothing can beat learning by practice. So let's create our own API. Our theme is a bike shop, so that's how we'll be modelling our RESTful routes.
 
-Cyclic offers its users with a variety of starter templates, and REST APIs are included, of course. So let's begin our exciting journey by visiting [Cyclic's starters](https://docs.cyclic.sh/overview/starters) and deploying the [REST API](https://github.com/cyclic-software/starter-rest-api).
+Cyclic offers its users a variety of starter templates, and REST APIs are included, of course. So let's begin our exciting journey by visiting [Cyclic's starters](https://docs.cyclic.sh/overview/starters) and deploying the [REST API](https://github.com/cyclic-software/starter-rest-api).
 
 [![Deploy to Cyclic](https://deploy.cyclic.sh/button.svg)](https://app.cyclic.sh/api/app/deploy/cyclic-software/starter-rest-api)
 
@@ -313,7 +313,7 @@ This will fork the aforementioned starter repository to your own GitHub account 
 
 Proceed by cloning the repository to your local machine using the `git clone` command, which you can copy from GitHub. Make sure that `git` is installed on your machine, of course.
 
-We'll be using ECMA6 import and export statement in this project, so open `package.json` and set the project's type to "module".
+We'll be using ECMA6 import and export statements in this project, so open `package.json` and set the project's type to "module".
 
 ```json
 // package.json
@@ -332,11 +332,11 @@ import db from "cyclic-dynamodb";
 
 [Link to full code.](https://github.com/cyclic-software/tutorial-bikes-api/blob/main/index.js)
 
-And since we're building our API around our a DynamoDB database, we need to make sure that we have read and write access to it by exporting the keys provided by Cyclic's "**Data/Storage**" dashboard to our local machine. (do this every time you launch the terminal)
+And since we're building our API around our DynamoDB database, we need to make sure that we have read and write access to it by exporting the keys provided by Cyclic's "**Data/Storage**" dashboard to our local machine. (do this every time you launch the terminal)
 
 <p align="center"><img alt="Copying database credentials to clipboard" src="/img/tutorial/rest-api/screencast1.gif" width="640" /></p>
 
-Cyclic does this automatically for us in production-mode, however. So we don't need to worry about this task when deploying our API.
+Cyclic does this automatically for us in production mode, however. So we don't need to worry about this task when deploying our API.
 
 Remember when we mentioned Node's package manager (NPM) that we used to get access to Express? Well, GitHub repositories that use NPM only contain the _names_ and _versions_ of used packages, but not the actual packages themselves.
 
@@ -346,7 +346,7 @@ Whenever we clone a GitHub repository, we must run `npm install` to actually _do
 
 <p align="center"><img alt="Bike collection containing eight fields: vendor, available for sale, total inventory, price range, title, product type, created at, description." src="/img/tutorial/rest-api/BikesDB.png" width="640" /></p>
 
-Before we get started, it's important to note that every AWS DynamoDB instance has a specific name, also known as a _table name_. It's given to us by Cyclic in its database dashboard page.
+Before we get started, it's important to note that every AWS DynamoDB instance has a specific name, also known as a _table name_. It's given to us by Cyclic on its database dashboard page.
 
 <p align="center"><img alt="Copying table name to the clipboard." src="/img/tutorial/rest-api/screencast2.gif" width="640" /></p>
 
@@ -371,7 +371,7 @@ curl http://localhost:3000/bikes/hybrid%20bike \
     -XPOST -H 'Content-Type: application/json'| jq .
 ```
 
-As you can see, _local_ servers are hosted on the [`localhost`](http://localhost) domain or [`127.0.0.1`](http://127.0.0.1) IP address. It's also common to see them running on the `3000` port, as being done in this server. (`8000`, `8080`, `5000` are also equally as common)
+As you can see, _local_ servers are hosted on the [`localhost`](http://localhost) domain or [`127.0.0.1`](http://127.0.0.1) IP address. It's also common to see them running on the `3000` port, as being done on this server. (`8000`, `8080`, and `5000` are also equally as common)
 
 [Learn more about local hosting and ports.](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/set_up_a_local_testing_server)
 

--- a/docs/tutorials/rest-api-and-dynamodb/part-2.md
+++ b/docs/tutorials/rest-api-and-dynamodb/part-2.md
@@ -91,7 +91,7 @@ const bikesCollection = db.collection("bikes");
 
 [Link to full code.](https://github.com/cyclic-software/tutorial-bikes-api/blob/main/router.js)
 
-As you can see, we're using the `cyclic-dynamodb` library to create a programmable instance of our database. That's a convenience library used to facilitate communication with our database using simple JavaScript code. We're also extracting the `CYCLIC_DB` environment variable that we set earlier using `process.env`.  
+As you can see, we're using the `cyclic-dynamodb` library to create a programmable instance of our database. That's a convenience library used to facilitate communication with our database using simple JavaScript code. We're also extracting the `CYCLIC_DB` environment variable that we set earlier using `process.env`. 
 
 Let's move back into our route handler to finally make some use of this `bikesCollection` object:
 

--- a/docs/tutorials/rest-api-and-dynamodb/part-2.md
+++ b/docs/tutorials/rest-api-and-dynamodb/part-2.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 <p align="center"><img alt="Four HTTP GET routes: list all, get by id, get by handle, and search by title." src="/img/tutorial/rest-api/GET_Routes.png" width="640" /></p>
 
-With our database full with data, it's time to build a RESTful API that allows us to fetch that data in four different ways:
+With our database full of data, it's time to build a RESTful API that allows us to fetch that data in four different ways:
 
 1. GET all bikes
 2. GET bike by ID
@@ -72,12 +72,12 @@ router.get("/all", async (req, res) => {
 
 [Link to full code.](https://github.com/cyclic-software/tutorial-bikes-api/blob/main/router.js)
 
-As you can see, we're telling Express to handle the GET action on the `/all` route by running the `router.get` method. If we wished to support the POST action instead for example, we would do `router.post`, as we'll see in the next section of this guide.
+As you can see, we're telling Express to handle the GET action on the `/all` route by running the `router.get` method. If we wished to support the POST action instead, for example, we would use `router.post`, as we'll see in the next section of this guide.
 
 Route handlers also take a [callback function](https://developer.mozilla.org/en-US/docs/Glossary/Callback_function) as their second parameter; that's a function that takes two parameters itself:
 
-- **HTTP Request:** as the first parameter passed to this function (which we conveniently named `req`), it's an object that contains all kinds of information about the HTTP request including but not limited to the query strings, body data and even HTTP headers.
-- **HTTP Response:** this is the second parameter, and it's used to fill the HTTP response with some information before sending it back to the client using the `res.send` method. For now, we're simply returning an empty `Array`, but we'll soon populate it with bikes data.
+- **HTTP Request:** as the first parameter passed to this function (which we conveniently named `req`), it's an object that contains all kinds of information about the HTTP request including but not limited to the query strings, body data, and even HTTP headers.
+- **HTTP Response:** this is the second parameter, and it's used to fill the HTTP response with some information before sending it back to the client using the `res.send` method. For now, we're simply returning an empty `Array`, but we'll soon populate it with bike data.
 
 And notice how we're using an [asynchronous function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) as the callback. While not required, it's important to note that it's well-supported with Express, and we'll be using it to wait for DynamoDB to return its data. Of course, we could also use [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) instead.
 
@@ -91,7 +91,7 @@ const bikesCollection = db.collection("bikes");
 
 [Link to full code.](https://github.com/cyclic-software/tutorial-bikes-api/blob/main/router.js)
 
-As you can see, we're using the `cyclic-dynamodb` library to create a programmable instance of our database. That's a convenience library used to facilitate the communication with our database using simple JavaScript code. We're also extracting the `CYCLIC_DB` environment variable that we set earlier using `process.env`. 
+As you can see, we're using the `cyclic-dynamodb` library to create a programmable instance of our database. That's a convenience library used to facilitate communication with our database using simple JavaScript code. We're also extracting the `CYCLIC_DB` environment variable that we set earlier using `process.env`.  
 
 Let's move back into our route handler to finally make some use of this `bikesCollection` object:
 
@@ -165,7 +165,7 @@ router.get("/:id", async (req, res) => {
 
 [Link to full code.](https://github.com/cyclic-software/tutorial-bikes-api/blob/main/router.js)
 
-As you can see, we're inserting `:id` into our URL and proceed to extract it from the `req.params` object.
+As you can see, we're inserting `:id` into our URL and proceeding to extract it from the `req.params` object.
 
 With the ID now in our hands, we can use that code snippet we just saw to extract specific data from DynamoDB:
 
@@ -286,13 +286,13 @@ curl http://localhost:3000/bikes/by-handle/<HANDLE> | jq . # replace <HANDLE> wi
 ```
 <p align="center"><img alt="Response to the last command." src="/img/tutorial/rest-api/api-handle.svg" width="640" /></p>
 
-## Fetching bikes by search on title
+## Fetching bikes by searching on the title
 
-Search is one of the most important features in a website. It's how users discover new products without having to browse a list of hundreds or even thousands of items. Implementing it, however, is not so simple.
+Search is one of the most important features of a website. It's how users discover new products without having to browse a list of hundreds or even thousands of items. Implementing it, however, is not so simple.
 
 The most popular search engines have to take a plethora of things into account: ignoring pronouns and uppercase characters, handling misspelled words, etc…
 
-In fact, DynamoDB comes with full support for [ElasticSearch](https://aws.amazon.com/about-aws/whats-new/2015/08/amazon-dynamodb-elasticsearch-integration/), a powerful search engine developed  used by some of the biggest applications out there.
+In fact, DynamoDB comes with full support for [ElasticSearch](https://aws.amazon.com/about-aws/whats-new/2015/08/amazon-dynamodb-elasticsearch-integration/), a powerful search engine developed and used by some of the biggest applications out there.
 
 But for the purposes of this tutorial, we'll stick with something more simple. DynamoDB also supports scans: SQL-like querying that handles many powerful [expressions](https://docs.aws.amazon.com/cli/latest/reference/dynamodb/scan.html).
 
@@ -313,7 +313,7 @@ router.get("/search/by-title", async (req, res) => {
 
 [Link to full code.](https://github.com/cyclic-software/tutorial-bikes-api/blob/main/router.js)
 
-Let's proceed now by using this search term to look-up some data. The function that we're looking for is `parallel_scan`, taking the expression `contains(title, <TERM>)`. However, we must split this expression into its three parts:
+Let's proceed now by using this search term to look up some data. The function that we're looking for is `parallel_scan`, taking the expression `contains(title, <TERM>)`. However, we must split this expression into three parts:
 
 1. **The expression itself:** `contains()`
 2. **The attribute name:** `title`

--- a/docs/tutorials/rest-api-and-dynamodb/part-2.md
+++ b/docs/tutorials/rest-api-and-dynamodb/part-2.md
@@ -79,7 +79,7 @@ Route handlers also take a [callback function](https://developer.mozilla.org/en-
 - **HTTP Request:** as the first parameter passed to this function (which we conveniently named `req`), it's an object that contains all kinds of information about the HTTP request including but not limited to the query strings, body data and even HTTP headers.
 - **HTTP Response:** this is the second parameter, and it's used to fill the HTTP response with some information before sending it back to the client using the `res.send` method. For now, we're simply returning an empty `Array`, but we'll soon populate it with bikes data.
 
-And notice how we're using an [asynchronous function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) as the callback. While not required, it's important to note that it's well-supported with Express and we'll be using it to wait for DynamoDB to return its data. Of course, we could also use [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) instead.
+And notice how we're using an [asynchronous function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) as the callback. While not required, it's important to note that it's well-supported with Express, and we'll be using it to wait for DynamoDB to return its data. Of course, we could also use [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) instead.
 
 It's time to start making calls to our DynamoDB instance to actually fetch some data. Let's get started by creating an instance of our bikes collection, giving us access to a variety of methods for manipulating our database:
 

--- a/docs/tutorials/rest-api-and-dynamodb/part-3.md
+++ b/docs/tutorials/rest-api-and-dynamodb/part-3.md
@@ -12,7 +12,7 @@ Our API is now given the ability to fetch data in a variety of ways, but it woul
 
 Our RESTful API should have an endpoint that accepts bike data, with *all* of its fields except for the ID and handle, which will be both automatically generated within our server.
 
-It's worth noting that POST body data can be in a variety of data-types, hinted in the [`Accept`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept) HTTP header. But having declared `app.use(express.json())` in our `index.js` file (it already came with the starter), we can directly access the body data in JSON format by extracting it from the `req.body` property.
+It's worth noting that POST body data can be in a variety of data types, hinted in the [`Accept`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept) HTTP header. But having declared `app.use(express.json())` in our `index.js` file (it already came with the starter), we can directly access the body data in JSON format by extracting it from the `req.body` property.
 
 ```javascript
 // Post new bike
@@ -181,7 +181,7 @@ router.put("/:id", async (req, res) => {
 
 [Link to full code.](https://github.com/cyclic-software/tutorial-bikes-api/blob/main/router.js)
 
-What we're doing here is first checking if the bike item exists by retrieving its ID, and we're then validating the data, deleting the existing item and replacing it with a new item.
+What we're doing here is first checking if the bike item exists by retrieving its ID, and we're then validating the data, deleting the existing item, and replacing it with a new item.
 
 ```json
 // request.json (remove this line from the actual file!)

--- a/docs/tutorials/rest-api-and-dynamodb/part-4.md
+++ b/docs/tutorials/rest-api-and-dynamodb/part-4.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # Finishing up with routes to update and delete data
 
-<p align="center"><img alt="Two HTTP routes: delete bike and update parts of bike." src="/img/tutorial/rest-api/PATCH__DELETE_Routes.png" width="640" /></p>
+<p align="center"><img alt="Two HTTP routes: delete bike and update parts of a bike." src="/img/tutorial/rest-api/PATCH__DELETE_Routes.png" width="640" /></p>
 
 We're almost done; but we still must implement two more route handlers: PATCH and DELETE.
 
@@ -24,7 +24,7 @@ router.patch("/:id", async (req, res) => {
 
 [Link to full code.](https://github.com/cyclic-software/tutorial-bikes-api/blob/main/router.js)
 
-Next step is to check whether or not a bike item with this ID exists, before we update anything.
+The next step is to check whether or not a bike item with this ID exists before we update anything.
 
 ```javascript
 // Patch bike if it exists
@@ -84,7 +84,7 @@ curl -X PATCH -H "Content-Type: application/json" http://localhost:3000/bikes/<I
 
 It wouldn't be a big stretch to say that this is the simplest route of the bunch.
 
-First step is to get the ID from the route parameters:
+The first step is to get the ID from the route parameters:
 
 ```javascript
 // Delete bike if it exists

--- a/docs/tutorials/rest-api-and-dynamodb/part-4.md
+++ b/docs/tutorials/rest-api-and-dynamodb/part-4.md
@@ -8,7 +8,7 @@ sidebar_position: 4
 
 We're almost done; but we still must implement two more route handlers: PATCH and DELETE.
 
-The former allows clients to update only *parts* of a bike item, as opposed to PUT which always replaces the whole thing. The latter is quite self-explanatory and it simply deletes the item in demand.
+The former allows clients to update only *parts* of a bike item, as opposed to PUT which always replaces the whole thing. The latter is quite self-explanatory, and it simply deletes the item in demand.
 
 ## Updating parts of a bike item
 

--- a/docs/tutorials/rest-api-and-dynamodb/part-5.md
+++ b/docs/tutorials/rest-api-and-dynamodb/part-5.md
@@ -53,7 +53,7 @@ node generate-secret.js
 ```
 <p align="center"><img alt="Response to the last command." src="/img/tutorial/rest-api/gen-token.svg" width="640" /></p>
 
-Copy that token and paste it in your `.env` file with the key name: `"TOKEN_SECRET"`.
+Copy that token and paste it into your `.env` file with the key name: `"TOKEN_SECRET"`.
 
 Let's delve back into our code:
 
@@ -157,7 +157,7 @@ curl -H "Authorization: Bearer $TOKEN" -X DELETE http://localhost:3000/bikes/<ID
 
 ## Deploying our API to the web, with Cyclic
 
-We just created a full-fledged RESTful API that could be used to build an e-commerce store for bikes. Through this journey, we learnt about servers, HTTP, RESTful APIs, AWS DynamoDB and how Cyclic brings all these technologies together into one using its distinct starter templates.
+We just created a full-fledged RESTful API that could be used to build an e-commerce store for bikes. Through this journey, we learnt about servers, HTTP, RESTful APIs, AWS DynamoDB, and how Cyclic brings all these technologies together into one using its distinct starter templates.
 
 [![Deploy to Cyclic](https://deploy.cyclic.sh/button.svg)](https://deploy.cyclic.sh/cyclic-software/tutorial-bikes-api)
 

--- a/docs/tutorials/rest-api-and-dynamodb/part-5.md
+++ b/docs/tutorials/rest-api-and-dynamodb/part-5.md
@@ -14,7 +14,7 @@ And while there are various authentication methods out there, [Bearer](https://s
 
 It's quite simple: we give users a token (they're the *bearer* of that token), we give that token some privileges (such as only reading or also writing and deleting) and finally we require the use of that token when making [unsafe HTTP requests](https://developer.mozilla.org/en-US/docs/Glossary/Safe/HTTP).
 
-We won't be implementing privileges and roles to keep this guide simple, but we'll be using Bearer authentication. Get started by installing the [`jsonwebtoken`](https://www.npmjs.com/package/jsonwebtoken) package; it's an implementation of [JSON Web Tokens](https://jwt.io/), an standard for creating and checking credentials across the Internet.
+We won't be implementing privileges and roles to keep this guide simple, but we'll be using Bearer authentication. Get started by installing the [`jsonwebtoken`](https://www.npmjs.com/package/jsonwebtoken) package; it's an implementation of [JSON Web Tokens](https://jwt.io/), a standard for creating and checking credentials across the Internet.
 
 After that, create an `auth.js` file, which will contain two important utilities for Bearer authentication.
 
@@ -90,7 +90,7 @@ router.delete("/:id", authenticateUser, ... )
 
 [Link to full code.](https://github.com/cyclic-software/tutorial-bikes-api/blob/main/router.js)
 
-And yes, the second parameter just became the middlware function, while the route handler was pushed to the next position. This is totally possible because JavaScript supports a [clever workaround](https://stackoverflow.com/a/457589) for [overloading](https://en.wikipedia.org/wiki/Function_overloading), a programming language feature that allows functions to have the same names but different parameters.
+And yes, the second parameter just became the middleware function, while the route handler was pushed to the next position. This is totally possible because JavaScript supports a [clever workaround](https://stackoverflow.com/a/457589) for [overloading](https://en.wikipedia.org/wiki/Function_overloading), a programming language feature that allows functions to have the same names but different parameters.
 
 Let's try it out now:
 
@@ -163,7 +163,7 @@ We just created a full-fledged RESTful API that could be used to build an e-comm
 
 <p align="center"><img alt="Deployments tab in Cyclic dashboard showing the deployment history." src="/img/tutorial/rest-api/app.cyclic.sh_.png" width="640" /></p>
 
-Let's commit all our new changes back into our code repository and let Cyclic automatically deploy these new changes to the web. We can track this process in Cylic's Deployments dashboard.
+Let's commit all our new changes back into our code repository and let Cyclic automatically deploy these new changes to the web. We can track this process in Cyclic's Deployments dashboard.
 
 <p align="center"><img alt="Variables tab in Cyclic dashboard showing two environment variables: token secret and cyclic DB." src="/img/tutorial/rest-api/ENV.png" width="640" /></p>
 
@@ -184,4 +184,4 @@ We could still add a variety of endpoints to our API:
 
 and many more things. You can get as creative as you want with it, you'll only be learning new things along the way!
 
-Get inspired by the plethora of [public APIs](https://github.com/public-apis/public-apis) out there, attempt rebuilding them while adding your own personal touch, deploy them on Cyclic and you'll soon be the one teaching all this stuff! 💪
+Get inspired by the plethora of [public APIs](https://github.com/public-apis/public-apis) out there, attempt rebuilding them while adding your own personal touch, deploy them on Cyclic, and you'll soon be the one teaching all this stuff! 💪

--- a/src/theme/SearchBar/algolia.css
+++ b/src/theme/SearchBar/algolia.css
@@ -10,7 +10,7 @@
 .algolia-docsearch-suggestion--highlight {
   color: #3a33d1;
 }
-/* Highligted search terms in the main category headers */
+/* Highlighted search terms in the main category headers */
 .algolia-docsearch-suggestion--category-header
   .algolia-docsearch-suggestion--highlight {
   background-color: #4d47d5;


### PR DESCRIPTION
I sincerely apologize for making you review the incredible amount of commits, the length of the following summary, and basically everything else about this pull request for such types of changes

_maybe consider squash merging if this is approved? I wouldn't think 62 commits is exactly appropriate for this type of change_

**/README.md**
- Use proper capitalization for word `GitHub` (d1947dd)

**/src/theme/SearchBar/algolia.css**
- Fix typo of word `Highlighted` (8519e82)

**/docs/quick-start.md**
* Use proper capitalization for word `GitHub` (822faad)
* Change `chose` to `choose` in `This will let you chose a repo` (L21) (5e6c232)
* Remove whitespace in `Quick start` (L8) (02ad7b3)

**/docs/index.md**
* Add hyphen between `Self hosting` (a6826f0)
* Use proper capitalization for word `GitHub` (a6826f0)
* Add `and` after the last comma in `no servers, no containers, no images, no hours to count` (L13) (53f1be8)
* Add `the` before `free tier` (L17, L27, L33) (53f1be8)
* Add comma before `and` in `ready on-demand, immediately and at all times` (L17) (53f1be8)
* Add `the` before `Cyclic free tier` in `On Cyclic free tier` (L27) (53f1be8)
* Add `the` before `default active-active failover strategy` on line 37 (53f1be8)
* Add `and` after the last comma in `When **apps grow up**, take them with you, integrate them into` (L41) (53f1be8)
* Add `the` before `"Cyclic - Preview" app` in `Approve "Cyclic - Preview" app in GitHub` (L67) (53f1be8)
* Change `in GitHub` to `on GitHub` (L67) (53f1be8)
* Add comma before `and` in `Cyclic supports Node.js 18, 16 and 14 runtimes` (L73) (53f1be8)
* Add hyphen in `hyper scale` (L23, L26) (7dc2051)
* Remove bold format (double asterisks) from `Hyper-scale` `danger` text, as `danger` text are already bold (L26) (7dc2051)
* Add `and` after the comma in `We are developers here, sometimes we want to open the box` (L41) (7dc2051)

**/docs/concepts/apps.md**
* Add hyphen between `fault tolerant` (07cd4132489663477f46b851a2e8ba6f4b982033)
* Add comma after `Therefore` (07cd4132489663477f46b851a2e8ba6f4b982033)
* Add comma before `etc.` in `Lambda, ApiGateway, SNS/SQS etc.` (L8) (04b6d86)
* Add comma before `and` in `provisioning, upgrades, instrumentation, configuration and cloud best practices` (L16) (04b6d86)
* Add comma before `or` in `change logic, manage clusters, tune parameters or deploy anything` (L18) (04b6d86)

**/docs/concepts/auth.md**
* Make `user name` a single word (4fcd3c4c4bc8c5ae1e04c3269feaed69fc5a1cb7)
* Add comma after `At some point` in `At some point applications may require` (L12) (1158cb8)
* Add comma after `Currently` on line 58 (1158cb8)
* Add `the` before `Basic auth scheme` on line 58 (1158cb8)

**/docs/concepts/database.md**
* Remove apostrophes from `it's` and `SDK's` (8e655b07dfb704f6fef262b30a15bc4cc23acea7)
* Fix whitespace in the database table (bde12b940c900b04cbf7b318843cb8187959a5d3)
* Change `On top of DynamoDB NoSQL functionality and table there is a number` to `On top of DynamoDB NoSQL functionality and table, there are a number` (L12) (35d0e54)
* Change `on local` to `locally` in `When developing and interacting with AWS on local` (L20) (35d0e54)
* Add comma before `and` in `records, queries and data scheme` (L31) (35d0e54)
* Change `them` to `the` in `list of props by which them item will be indexed` (L52) (35d0e54)
* Add hyphen between `open source` (L99) (35d0e54)
* Add hyphen between `third party` (L101) (35d0e54)

**/docs/concepts/env_vars.md**
* Change `injects` to `inject` in `used in package.json scripts to inject variables` (L19) (a723c681a263fd9fea07bb7b9ad865242f1d482e)
* Change `Make sure to add .env file to your .gitignore.` to `Make sure to add .env to your .gitignore file.` (L14) (316f969)
* Add `the` before `application code` in `without changes to application code` (L19) (316f969)
* Change `environments` to `environment's` in `the app environments unique id` (L52) (316f969)
* Add `the` before `first deployment` in `variables in first deployment` (L84) (316f969)
* Change `you` to `to` in `would like you add your own credentials` (L104) (316f969)

**/docs/concepts/file_system.md**
* Change `perminant` to `permanent` (L14) (1c99349)
* Change `perminant` to `permanent` and `acces` to `access` (L16) (1c99349)
* Change `on` to `in` in `access to the file system on your local environment` (L7) (4a9b17f)
* Rephrase `The `fs` method is often used for ... files, however there is a long list of methods, which you can see here in` to `The `fs` module is often used for ... files, though there is a long list of methods that you can see in` (4a9b17f)

**/docs/concepts/hosting.md**
* Add comma before `and` in `manage deployments, config and features` (L12) (1350468)
* Add comma before `and` in `customize, take apart and tinker` (L12) (1350468)

**/docs/concepts/storage.md**
* Add hyphen in `S3 compatible` in `Any AWS S3 compatible client` (L6) (5d321b7)
* Remove unnecessary `for` in `AWS environment variables that provide for access to the app` (L10) (5d321b7)
* Rephrase `To access the bucket from local, go to the storage tab of the app, copy credentials and paste on` to `To access the bucket locally, go to the storage tab of the app, copy the credentials, and paste them on` (L12) (5d321b7)
* Add comma after `Cyclic` in `As with running on Cyclic you will need to provide` (L12) (5d321b7)
* Change `Catch all handler for all other request` to `Catch all handlers for all other requests` (L96) (5d321b7)

**/docs/concepts/transactions.md**
* Add comma before `and` in `tooling that captures, measures and aggregates` (L9) (c5c10c7)
* Add comma before `and` in `network requests, responses, application logs, errors and exceptions` (L9) (c5c10c7)
* Add `the` before `console` in `App logging output to console` (L22) (c5c10c7)
* Add whitespace after comma in line 24 (c5c10c7)
* Add comma before `and` in `timeline of the logs, errors and exceptions` (L56) (c5c10c7)
* Change comma to `and` in `in an easy to read, syntax highlighted timeline as:` (L56) (c5c10c7)
* Add hyphens in `easy to read` and `syntax highlighted` (L56) (c5c10c7)

**/docs/how-to/add-private-repository.md**
* Change list numbers from *all* `1`s to the correct range (L10-L15) (2b38b15)
* Correctly capitalize `GitHub` (L14) (2b38b15)
* Add `the` before `Cyclic app` in `In the GitHub pop up add Cyclic app` (L14) (fb48d4b)
* Add comma before `add` in `In the GitHub pop up add Cyclic app` (L14) (fb48d4b)

**/docs/how-to/create-deploy-to-cyclic-button.md**
* Change `Github` to `GitHub` (L12, L24) (da132f0)
* Change `user name` to `username` (L24) (da132f0)
* Add comma after `For example` in `For example, if you wanted to` (L26) (05dea40)

**/docs/how-to/using-mongo-db.md**
*  Change `IP's` to `IPs` (L9, L11) (a7ce511)
* Change `white listing` to `whitelisting` (L9) (c2780dd)
* Add `the` before `free tier` in `private networking on free tier` (L9) (c2780dd)
* Add `a` before `connection string` in `authenticate via a connection string` (L11) (c2780dd)
* Remove extra whitespace on line 20 immediately after the list-hyphen (c2780dd)
* Remove extra whitespace on line 22 between words (c2780dd)

**/docs/how-to/custom-domains/godaddy.md**
* Add comma after `for example` in `Link a subdomain, for example api.example.com` (L9) (51ce39d)
* Add `the` before `Cyclic dashboard` (L37) (51ce39d)
* Add `a` before `redirect` in `forwarding in GoDaddy to set up redirect from` (L49) (51ce39d)
* Add `the` before `SSL certificate` in `set up the records and SSL certificate was issued` (L55) (51ce39d)
* Change `wwww.example.com` (4 `w`s) to `www.example.com` (L56) (51ce39d)

**/docs/how-to/custom-domains/namecheap.md**
* Fix list numbering (was `1., 2., 1., 2., 3.`, L11-L18) (4c428da)
* Remove `to` in `pointing of your custom URL to from Namecheap` (L37) (03de766)

**/docs/how-to/custom-domains/overview.md**
* Remove `a` in `select a any custom domain` (L16) (55859a6)
* Add `the` before `first deployment` in `random subdomain names at first deployment` (L8) (4be2ed8)
* Add `the` before `cyclic app` in `route requests between your domain and cyclic app` (L20) (4be2ed8)
* Capitalize `cyclic` in line 20 (4be2ed8)

**/docs/overview/architecture.md**
* Change `trade offs` to `trade-offs` (L29) (3f120c0)
* Add comma after `does` in `When it does, we should` (L49) (3f120c0)
* Capitalize `Twitter` (L5) (3f120c0)
* Add `the` before `first launch` in `At first launch we select` (L9) (e1a27d1)
* Add comma after `At first launch` (L9) (e1a27d1)
* Add comma after `For subsequent launches` (L11) (e1a27d1)
* Change `anytime` to `any time` (L57) (e1a27d1)

**/docs/overview/build.md**
* Change `Github` to `GitHub` (L11, L13) (8bc7033)
* Add comma before `or` in `beyond what these lifecycle scripts can provide or they don't` (L54) (8bc7033)
* Add comma before `send` in `or they don't solve for your use case, send us an email` (L54) (8bc7033)
* Add period at the end of the sentence on line 54 (8bc7033)
* Add `the` before `first installation` in `On first installation we will assign` (L13) (b3831cb)
* Add comma after `On [the] first installation` in `On [the] first installation we will assign` (L13) (b3831cb)
* Add comma after `needs` in `If you have particular needs try putting` (L54) (b3831cb)
* Change `it` to `them` in `If you have particular needs try putting it into` (L54) (b3831cb)
* Remove `for` in `or they don't solve for your use case` (L54) (b3831cb)
* Add `the` before `first deployment` in `at the time of first deployment, in` (L65) (b3831cb)
* Add comma after `For example` in `For example, for a repository` (L72) (b3831cb)
* Rephrase `For example if at the end of the above build, a build directory is generated inside /frontend` to `For example, if a build directory is generated inside /frontend at the end of the above build` (L85) (b3831cb)

**/docs/overview/deploy.md**
* Change `Github` to `GitHub` (L17) (0e1f2c2)
* Rephrase `For deployments that take place into Cyclic managed accounts this means there is nothing else to worry about.` to `For deployments that take place in Cyclic-managed accounts, this means that there is nothing else to worry about.` (L9) (ce84518)
* Remove apostrophe in `it's` in `Code is deployed as soon as it's GitHub repository` (L12) (ce84518)
* Remove unnecessary double whitespace before `main` on line 12 (ce84518)
* Add hyphen between `right hand` in `right hand side of the page` (L17) (ce84518)

**/docs/overview/launch.md**
* Add comma before `and` in `no servers to manage, no OS patches to apply, no maintenance windows to schedule and no networking headaches` (L7) (40c79cf)
* Add `the` before `entry point` in `the full sequence of fallbacks to identify entry point` (L36) (40c79cf)
* Change `you` to `your` in `If you code fails to initialize` (L54) (40c79cf)

_unbelievable, you're actually reading the entire summary_

**/docs/overview/limits.md**
* Add comma before `but` in `Soft limits may be changed but they require` (L9) (ce77090)
* Change `they require a conversation with us and depending on the use case possibly a paid plan` to `they require a conversation with us and, depending on the use case, possibly a paid plan` (L9) (ce77090)
* Add comma before `but` in `the data will persist between invokes but there is no guarantee` (L20) (ce77090)

**/docs/overview/starters.md**
* Change `DM's` to `DMs` in `Discord Bot starter DMs and Slash` (L81) (bf7fc42)
* Add comma before `and` in `Telegram inline queries, commands and interactive inline keyboards` (L88) (7aaff55)

**/docs/serverless/on-demand.md**
* Change `long running` to `long-running` (L27) (c4729d0)
* Remove hyphen in `use-case` from `choose an appropriate polling rate for your use-case` (L16) (4913743)
* Add hyphen in `one second` from `one second resolution` (twice on line 29) (4913743)
* Add `an` before `instantaneous` in `do not require instantaneous real-time push` (L14) (7c87abc)
* Add `the` before `server` in `real-time push from server` (L14) (7c87abc)
* Change `written to on local or in a persistent environment` to `written to a local or persistent environment` (7c87abc)

**/docs/serverless/stateless.md**
* Change `read's` to `reads` and `write's` to `writes` in `may work for some *very* low volume of read's and write's` (L33) (fa93fff)
* Change `amd` to `and` in `Cyclic apps run on read-only file systems amd do not retain` (L6) (059619d)
* Remove hyphen in `use-cases` in `Special precautions should be used for the following use cases` (L10) (059619d)
* Remove hyphen in `re-start` and `re-starts` (twice on line 13) (059619d)
* Add hyphen in `Database backed` from `Database backed sessions` (L15) (059619d)
* Remove unnecessary leading whitespace on line 18 (059619d)
* Add `your` before `apps'` in `npm package that will let you use apps' built-in AWS` (L18) (059619d)
* Add comma before `and` in `pre-signed GET, PUT and POST urls` (L25) (059619d)
* Add `it` after `download` in `upload the result to an object store or download to the client` (L30) (059619d)

**/docs/troubleshooting/error-codes.md**
* Shorten `in regards to` to `regarding` in `if you are receiving this message in regards to CORS` (L37) (3775cf5)
* Change `persay` to `per se` (L41) (3775cf5)
* Change `dependences` to `dependencies` (L42) (3775cf5)
* Change `varibales` to `variables` (L44) (3775cf5)
* Add `its` before `type` in `quickly find an error based on type` (L7) (b26fc98)
* Add hyphen in `30 second` (L22) (b26fc98)

**/docs/troubleshooting/main-entry-point-does-not-exist.md**
* Add comma after `By default` in `By default this will look for` (L26) (efb656a)
* Add comma after `By default` in `By default, when you run npm init` (L41) (efb656a)
* Change `in files other than `index.js` in the root directory. Hence the mismatch` to `in files other than `index.js` in the root directory, hence the mismatch` (L41) (efb656a)

**/docs/troubleshooting/no-space-left-on-device.md**
* Add comma after `By default` in `By default any generated files` (L11) (13d1bda)
* Add comma after `Currently` in `Currently the code size is limited` (L25) (13d1bda)
* Change `install` to `installation` in `while running the install or step` (L37) (13d1bda)
* Add `it` after `fix` in `here is how to fix` (L22) (68a3e9f)
* Add `the` before `installation` in `available for temporary use to run installation and build` (L35) (68a3e9f)
* Change `are can to` to `can` in `most projects are can to be optimized` (L25) (1372d90)

**/docs/troubleshooting/nodemon.md**
* Rephrase `Nodemon is an excellent tool for local development of node applications. On your local, nodemon watches for file changes at the path it is monitoring and restarts the local server. In production mode, both for serverless or not` to `Nodemon is an excellent tool for locally developing node applications. Locally, nodemon watches for file changes at the path it is monitoring and restarts the local server. In production mode, serverless or not` (L46) (2826e15)
* Rephrase `defined for the purpose of starting the application in production` to `defined to start the application in production` (L59) (2826e15)
* Add comma after `By convention` in `By convention the "dev" script is used` (L59) (2826e15)

**/docs/troubleshooting/websockets.md**
* Change `bi-directional` to `bidirectional` (L13) (3506057)
* Rephrase `the runtime is suspended until it is again invoked` to `the runtime is suspended until it is invoked again` (L11) (2751c6e)
* Remove unnecessary double whitespace on line 13 (2751c6e)

**/docs/tutorials/rest-api-and-dynamodb/part-1.md**
* Remove repeated word `make` in `We can also make make POST` (L214) (3506057)
* Add comma after `powerful` in `cURL is pretty powerful and we'll be using it` (L266) (3506057)
* Capitalize `GitHub` (L312, L314) (3506057)
* Change hyphen to whitespace in `ground-up` (L7) (dc62848)
* Change `its` to `their` in `into RESTful APIs, let's start from its origins` (L23) (dc62848)
* Add comma before `and` in `HTML documents, CSS stylesheets, images and video files` (L25) (dc62848)
* Change hyphen to whitespace in `takes in` in `software that takes-in URLs` (L27) (dc62848)
* Remove comma after `end-users` in `deliver content back to the end-users, while using the HTTP protocol to facilitate the sharing` (L27) (dc62848)
* Add comma before `or` in `search for a product, view details on it or even buy it` (L35) (dc62848)
* Add comma after `Success` in `Success for example, is represented` (L44) (dc62848)
* Add comma before `and` in `CSS files, JS files and other media` (L46) (dc62848)
* Change hyphen to whitespace in `building-blocks` in `servers are the building-blocks of the Internet` (L50) (dc62848)
* Add comma after `Internet` in `servers are the building-blocks of the Internet, and that they're responsible for` (L50) (dc62848)
* Change hyphen to whitespace in `end-user` in `show it to the end user` (L77) (dc62848)
* Remove comma before `while` in `It runs directly in the server operating system, while adding new modules` (L89) (dc62848)
* Add `a` before `"context shift"` in `developers experience less of "context shift"` (L91) (dc62848)
* Change `in` to `for` in `We'll be using Express in the remainder of this tutorial` (L154) (dc62848)
* Add hyphen in `all new` from `all new and updated Countach from Cyclic` (L234) (dc62848)
* Add comma before `and` in `speed, handling and durability` (L234) (dc62848)
* Change hyphen to whitespace in `looking-up` (L245) (dc62848)
* Remove hyphen from `inter-connected` (L274) (dc62848)
* Change hyphen to whitespace in `fixed-set` (L276) (dc62848)
* Add comma before `and` in `a name, a phone number and an email address` (L276) (dc62848)
* Change hyphen to whitespace in `data-type` (L276) (dc62848)
* Capitalize `noSQL` (twice on L278, once more on L290) (dc62848)
* Change `bikes shop` to `bike shop` (L292, L306) (dc62848)
* Add comma before `and` in `mix of Strings, Numbers and even whole Objects.` (L292) (dc62848)
* Remove `with` in `Cyclic offers its users with a variety of starter templates` (L308) (dc62848)
* Make `statement` plural in `We'll be using ECMA6 import and export statement` (L316) (dc62848)
* Add `a` before `DynamoDB database` in `we're building our API around our a DynamoDB database` (L335) (dc62848)
* Change hyphen to whitespace in `production-mode` (L339) (dc62848)
* Change `in` to `on` in `It's given to us by Cyclic in its database dashboard page` (L349) (dc62848)
* Change `in` to `on` in `running on the `3000` port, as being done in this server` (L374) (dc62848)
* Add `and` after last comma in `(8000, 8080, 5000 are also equally as common)` (L374) (dc62848)

**/docs/tutorials/rest-api-and-dynamodb/part-2.md**
* Add comma before `and` in `it's well-supported with Express and we'll be using it` (L82) (6ec111b)
* Change `full with data` to `full of data` (L9) (31e4506)
* Add comma before `for example` in `If we wished to support the POST action instead for example, we would` (L75) (31e4506)
* Change `do` to `use` in `we would do router.post` (L75) (31e4506)
* Add comma before `and` in `query strings, body data, and even HTTP headers` (L79) (31e4506)
* Make `bikes` singular in `we'll soon populate it with bikes data` (L80) (31e4506)
* Remove `the` in `library used to facilitate the communication with our database` (L94) (31e4506)
* Use progressive form for `proceed` in `we're inserting `:id` into our URL and proceed to extract it` (L168) (31e4506)
* Rephrase `Fetching bikes by search on title` to `Fetching bikes by searching on the title` (L289) (31e4506)
* Change `in` to `of` in `Search is one of the most important features in a website` (L291) (31e4506)
* Add `and` between `developed` and `used` in `a powerful search engine developed used by some of the biggest applications` (L295) (31e4506)
* Change hyphen to whitespace in `look-up` from `using this search term to look-up some data` (L316) (31e4506)
* Remove `its` from `we must split this expression into its three parts` (L316) (31e4506)

**/docs/tutorials/rest-api-and-dynamodb/part-3.md**
* Change hyphen to whitespace in `data-types` (L15) (31e4506)
* Add comma before `and` in `validating the data, deleting the existing item and replacing it with a new item` (L184) (31e4506)

**/docs/tutorials/rest-api-and-dynamodb/part-4.md**
* Add comma before `and` in `is quite self-explanatory and it simply deletes` (L11) (cf34d97)
* Add `a` before `bike` in `Two HTTP routes: delete bike and update parts of bike.` (L7) (31e4506)
* Add `The` before `next step` in `Next step is to check` (L27) (31e4506)
* Add comma before `before` in `check whether or not a bike item with this ID exists, before we update anything` (L27) (31e4506)
* Add `The` before `first step` in `First step is to get the ID` (L87) (31e4506)

**/docs/tutorials/rest-api-and-dynamodb/part-5.md**
* Change `an` to `a` in `implementation of [JSON Web Tokens], an standard` (L17) (88076a7)
* Change `middlware` to `middlware` (L93) (88076a7)
* Change `Cylic's` to `Cyclic's` (L166) (88076a7)
* Add comma before `and` in `adding your own personal touch, deploy them on Cyclic and you'll soon be` (L187) (88076a7)
* Change `in` to `into` in `Copy that token and paste it in your .env file` (L56) (31e4506)
* Add comma before `and` in `servers, HTTP, RESTful APIs, AWS DynamoDB and how Cyclic` (L160) (31e4506)
